### PR TITLE
Restore the missing routine in the conversion module

### DIFF
--- a/fink_science/conversion.py
+++ b/fink_science/conversion.py
@@ -38,6 +38,65 @@ def mag2fluxcal_snana(magpsf: float, sigmapsf: float):
 
     return fluxcal, fluxcal_err
 
+def apparent_flux(fid, magpsf, sigmapsf, magnr, sigmagnr, magzpsci, isdiffpos):
+    """ Compute apparent flux from difference magnitude supplied by ZTF
+    This was heavily influenced by the computation provided by Lasair:
+    https://github.com/lsst-uk/lasair/blob/master/src/alert_stream_ztf/common/mag.py
+    Paramters
+    ---------
+    fid
+        filter, 1 for green and 2 for red
+    magpsf,sigmapsf; floats
+        magnitude from PSF-fit photometry, and 1-sigma error
+    magnr,sigmagnr: floats
+        magnitude of nearest source in reference image PSF-catalog
+        within 30 arcsec and 1-sigma error
+    magzpsci: float
+        Magnitude zero point for photometry estimates
+    isdiffpos: str
+        t or 1 => candidate is from positive (sci minus ref) subtraction;
+        f or 0 => candidate is from negative (ref minus sci) subtraction
+
+    Returns
+    --------
+    dc_flux: float
+        Apparent magnitude
+    dc_sigflux: float
+        Error on apparent magnitude
+    """
+    if magpsf is None:
+        return None, None
+    # zero points. Looks like they are fixed.
+    ref_zps = {1: 26.325, 2: 26.275, 3: 25.660}
+    magzpref = ref_zps[fid]
+
+    # reference flux and its error
+    magdiff = magzpref - magnr
+    if magdiff > 12.0:
+        magdiff = 12.0
+    ref_flux = 10**(0.4 * magdiff)
+    ref_sigflux = (sigmagnr / 1.0857) * ref_flux
+
+    # difference flux and its error
+    if magzpsci == 0.0:
+        magzpsci = magzpref
+    magdiff = magzpsci - magpsf
+    if magdiff > 12.0:
+        magdiff = 12.0
+    difference_flux = 10**(0.4 * magdiff)
+    difference_sigflux = (sigmapsf / 1.0857) * difference_flux
+
+    # add or subract difference flux based on isdiffpos
+    if isdiffpos == 't':
+        dc_flux = ref_flux + difference_flux
+    else:
+        dc_flux = ref_flux - difference_flux
+
+    # assumes errors are independent. Maybe too conservative.
+    dc_sigflux = np.sqrt(difference_sigflux**2 + ref_sigflux**2)
+
+    return dc_flux, dc_sigflux
+
 def dc_mag(fid, magpsf, sigmapsf, magnr, sigmagnr, magzpsci, isdiffpos):
     """ Compute apparent magnitude from difference magnitude supplied by ZTF
     Parameters
@@ -64,7 +123,7 @@ def dc_mag(fid, magpsf, sigmapsf, magnr, sigmagnr, magzpsci, isdiffpos):
     if magzpsci is None:
         magzpsci = magzpref
 
-    dc_flux, dc_sigflux = dc_flux(
+    dc_flux, dc_sigflux = apparent_flux(
         fid, magpsf, sigmapsf, magnr, sigmagnr, magzpsci, isdiffpos
     )
 

--- a/fink_science/microlensing/processor.py
+++ b/fink_science/microlensing/processor.py
@@ -146,7 +146,7 @@ if __name__ == "__main__":
     ztf_alert_sample = 'fink_science/data/alerts/alerts.parquet'
     globs["ztf_alert_sample"] = ztf_alert_sample
 
-    model_path = 'fink_science/data/models/default-model.obj'
+    model_path = 'fink_science/data/models'
     globs["model_path"] = model_path
 
     # Run the test suite

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -60,6 +60,7 @@ do
   if [[ "$NO_SPARK" = true ]] && [[ ${filename##*/} = 'processor.py' ]] ; then
     echo '[NO SPARK] skipping' $filename
   else
+    echo $filename
     # Run test suite + coverage
     coverage run \
       --source=${ROOTPATH} \


### PR DESCRIPTION
This PR brings back the `dc_flux` routine in the conversion module, and rename it `apparent_flux`.