### PR TITLE
Use a condition while concatening columns to avoid nulls

### DIFF
--- a/fink_science/utilities.py
+++ b/fink_science/utilities.py
@@ -40,10 +40,13 @@ def concat_col(df, colname: str, prefix: str = 'c'):
     """
     return df.withColumn(
         prefix + colname,
-        F.concat(
-            df['prv_candidates.{}'.format(colname)],
-            F.array(df['candidate.{}'.format(colname)])
-        )
+        F.when(
+            df['prv_candidates.{}'.format(colname)].isNotNull(),
+            F.concat(
+                df['prv_candidates.{}'.format(colname)],
+                F.array(df['candidate.{}'.format(colname)])
+            )
+        ).otherwise(F.array(df['candidate.{}'.format(colname)]))
     )
 
 def extract_field(current: list, history: list) -> np.array:


### PR DESCRIPTION
This PR updates `concat_col` to avoid nulls when there is no history (#40 )

```
current = a_value
history = null

before
Row(objectId='ZTF19aakqaeh', cmagpsf=None)

after
Row(objectId='ZTF19aakqaeh', cmagpsf=[a_value])
```