### PR TITLE
[Asteroid] Updating the selection function

### DIFF
--- a/fink_science/asteroids/processor.py
+++ b/fink_science/asteroids/processor.py
@@ -65,7 +65,7 @@ def roid_catcher(jd, ndethist, sgscore1, ssdistnr, distpsnr1):
     >>> df = spark.read.load(ztf_alert_sample)
 
     # Required alert columns
-    >>> what = ['fid']
+    >>> what = ['jd']
 
     # Use for creating temp name
     >>> prefix = 'c'


### PR DESCRIPTION
This PR brings a new way to detect uncatalogued asteroids. The alerts are labeled using:
- [3] if the asteroid has been flagged by ZTF (in MPC within 5")
- [2] if the asteroid has been flagged by Fink
- [1] if is the first time ZTF sees this object (but not flagged by Fink as asteroid)
- [0] if it is likely not an asteroid (or we can't say anything)

To determine if the alert is a new asteroid, we use:
1. No stellar counterpart, sgscore1 < 0.76 (Tachibana & Miller 2018)
2. Number of detections is 1 or 2
3. No Panstarrs counterpart within 1"
4. If 2 detections, observations must be done within 30 min.

    