### PR TITLE
Added *csv files in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setuptools.setup(
             'data/models/*.sav',
             'data/models/*.npy',
             'data/models/*.pkl',
+            'data/models/*.csv'
             'data/models/snn_models/*/*.pt',
             'data/models/snn_models/*/*.json',
             'data/models/snn_models/*/*.txt'],


### PR DESCRIPTION
This will enable the file `components.csv` from `data/models` to be included in the packages. 
`components.csv` is loaded by default by `kilonova.processor.knscore`.