### PR TITLE
Bump to 0.4.6

### DIFF
--- a/fink_science/__init__.py
+++ b/fink_science/__init__.py
@@ -12,4 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.4.5"
+__version__ = "0.4.6"


### PR DESCRIPTION
### 0.4.5 to 0.4.6

- Fix missing `__init__.py` in the image classification module #111 

Thanks @FusRoman !