### PR TITLE
Speed up the Active learning & kilonova modules by flagging irrelevant objects

### DIFF
--- a/fink_science/kilonova/lib_kn.py
+++ b/fink_science/kilonova/lib_kn.py
@@ -15,6 +15,42 @@
 import numpy as np
 import pandas as pd
 
+def return_list_of_kn_host():
+    """ Return potential KN host names
+
+    This includes:
+    - List of object names in SIMBAD that would correspond to extra-galactic object
+    - Unknown objects
+    - objects with failed crossmatch
+
+    In practice, this exclude galactic objects from SIMBAD.
+
+    """
+    list_simbad_galaxies = [
+        "galaxy",
+        "Galaxy",
+        "EmG",
+        "Seyfert",
+        "Seyfert_1",
+        "Seyfert_2",
+        "BlueCompG",
+        "StarburstG",
+        "LSB_G",
+        "HII_G",
+        "High_z_G",
+        "GinPair",
+        "GinGroup",
+        "BClG",
+        "GinCl",
+        "PartofG",
+    ]
+
+    keep_cds = \
+        ["Unknown", "Candidate_SN*", "SN", "Transient", "Fail"] + \
+        list_simbad_galaxies
+
+    return keep_cds
+
 def get_features_name(npcs):
     """
     Create the list of feature names depending on the number of principal components.

--- a/fink_science/kilonova/processor.py
+++ b/fink_science/kilonova/processor.py
@@ -24,23 +24,32 @@ from fink_science.conversion import mag2fluxcal_snana
 from fink_science.utilities import load_scikit_model, load_pcs
 from fink_science.kilonova.lib_kn import extract_all_filters_fink
 from fink_science.kilonova.lib_kn import get_features_name
+from fink_science.kilonova.lib_kn import return_list_of_kn_host
 from fink_science import __file__
 
 from fink_science.tester import spark_unit_tests
 
 @pandas_udf(DoubleType(), PandasUDFType.SCALAR)
-def knscore(jd, fid, magpsf, sigmapsf, model_path=None, pcs_path=None, npcs=None) -> pd.Series:
+def knscore(jd, fid, magpsf, sigmapsf, jdstarthist, cdsxmatch, ndethist, model_path=None, pcs_path=None, npcs=None) -> pd.Series:
     """ Return the probability of an alert to be a Kilonova using a Random
     Forest Classifier.
+
+    You need to run the SIMBAD crossmatch before.
 
     Parameters
     ----------
     jd: Spark DataFrame Column
-        JD times (float)
+        JD times (vectors of floats)
     fid: Spark DataFrame Column
-        Filter IDs (int)
+        Filter IDs (vectors of ints)
     magpsf, sigmapsf: Spark DataFrame Columns
-        Magnitude from PSF-fit photometry, and 1-sigma error
+        Magnitude from PSF-fit photometry, and 1-sigma error (vectors of floats)
+    cdsxmatch: Spark DataFrame Column
+        Type of object found in Simbad (string)
+    ndethist: Spark DataFrame Column
+        Column containing the number of detection by ZTF at 3 sigma (int)
+    jdstarthist: Spark DataFrame Column
+        Column containing first time variability has been seen
     model_path: Spark DataFrame Column, optional
         Path to the trained model. Default is None, in which case the default
         model `data/models/KN_model_2PC.pkl` is loaded.
@@ -59,10 +68,14 @@ def knscore(jd, fid, magpsf, sigmapsf, model_path=None, pcs_path=None, npcs=None
 
     Examples
     ----------
+    >>> from fink_science.xmatch.processor import cdsxmatch
     >>> from fink_science.utilities import concat_col
     >>> from pyspark.sql import functions as F
 
     >>> df = spark.read.load(ztf_alert_sample)
+
+    >>> colnames = [df['objectId'], df['candidate.ra'], df['candidate.dec']]
+    >>> df = df.withColumn('cdsxmatch', cdsxmatch(*colnames))
 
     # Required alert columns
     >>> what = ['jd', 'fid', 'magpsf', 'sigmapsf']
@@ -77,10 +90,12 @@ def knscore(jd, fid, magpsf, sigmapsf, model_path=None, pcs_path=None, npcs=None
 
     # Perform the fit + classification (default model)
     >>> args = [F.col(i) for i in what_prefix]
+    >>> args += [F.col('candidate.jdstarthist'), F.col('cdsxmatch'), F.col('candidate.ndethist')]
     >>> df = df.withColumn('pKNe', knscore(*args))
 
     # Note that we can also specify a model
-    >>> extra_args = [F.lit(model_path), F.lit(comp_path), F.lit(2)]
+    >>> extra_args = [F.col('candidate.jdstarthist'), F.col('cdsxmatch'), F.col('candidate.ndethist')]
+    >>> extra_args += [F.lit(model_path), F.lit(comp_path), F.lit(2)]
     >>> args = [F.col(i) for i in what_prefix] + extra_args
     >>> df = df.withColumn('pKNe', knscore(*args))
 
@@ -99,6 +114,14 @@ def knscore(jd, fid, magpsf, sigmapsf, model_path=None, pcs_path=None, npcs=None
 
     # Flag empty alerts
     mask = magpsf.apply(lambda x: np.sum(np.array(x) == np.array(x))) > 1
+
+    mask *= (ndethist.astype(int) <= 20)
+
+    mask *= jd.astype(float).apply(lambda x: x[-1]) - jdstarthist.astype(float) < 20
+
+    list_of_kn_host = return_list_of_kn_host()
+    mask *= cdsxmatch.apply(lambda x: x in list_of_kn_host)
+
     if len(jd[mask]) == 0:
         return pd.Series(np.zeros(len(jd), dtype=float))
 

--- a/fink_science/kilonova/processor.py
+++ b/fink_science/kilonova/processor.py
@@ -117,7 +117,7 @@ def knscore(jd, fid, magpsf, sigmapsf, jdstarthist, cdsxmatch, ndethist, model_p
 
     mask *= (ndethist.astype(int) <= 20)
 
-    mask *= jd.astype(float).apply(lambda x: x[-1]) - jdstarthist.astype(float) < 20
+    mask *= jd.apply(lambda x: float(x[-1])) - jdstarthist.astype(float) < 20
 
     list_of_kn_host = return_list_of_kn_host()
     mask *= cdsxmatch.apply(lambda x: x in list_of_kn_host)

--- a/fink_science/random_forest_snia/classifier_sigmoid.py
+++ b/fink_science/random_forest_snia/classifier_sigmoid.py
@@ -25,6 +25,42 @@ columns_to_keep = ['MJD', 'FLT', 'FLUXCAL', 'FLUXCALERR']
 fluxes = ['FLUXCAL', 'FLUXCALERR']
 RF_FEATURE_NAMES = 'a_g,b_g,c_g,snratio_g,chisq_g,nrise_g,a_r,b_r,c_r,snratio_r,chisq_r,nrise_r'.split(',')
 
+def return_list_of_sn_host():
+    """ Return potential SN host names
+
+    This includes:
+    - List of object names in SIMBAD that would correspond to extra-galactic object
+    - Unknown objects
+    - objects with failed crossmatch
+
+    In practice, this exclude galactic objects from SIMBAD.
+
+    """
+    list_simbad_galaxies = [
+        "galaxy",
+        "Galaxy",
+        "EmG",
+        "Seyfert",
+        "Seyfert_1",
+        "Seyfert_2",
+        "BlueCompG",
+        "StarburstG",
+        "LSB_G",
+        "HII_G",
+        "High_z_G",
+        "GinPair",
+        "GinGroup",
+        "BClG",
+        "GinCl",
+        "PartofG",
+    ]
+
+    keep_cds = \
+        ["Unknown", "Candidate_SN*", "SN", "Transient", "Fail"] + \
+        list_simbad_galaxies
+
+    return keep_cds
+
 def filter_data(data, filt):
     """Select data according to the value of the
        filter (for ZTF only g, r)

--- a/fink_science/random_forest_snia/processor.py
+++ b/fink_science/random_forest_snia/processor.py
@@ -81,14 +81,17 @@ def rfscore_sigmoid_full(jd, fid, magpsf, sigmapsf, cdsxmatch, ndethist, model=N
     ...    df = concat_col(df, colname, prefix=prefix)
 
     # Perform the fit + classification (default model)
-    >>> args = [F.col(i) for i in what_prefix] + [F.col('cdsxmatch'), F.col('ndethist')]
+    >>> args = [F.col(i) for i in what_prefix]
+    >>> args += [F.col('cdsxmatch'), F.col('candidate.ndethist')]
     >>> df = df.withColumn('pIa', rfscore_sigmoid_full(*args))
 
     >>> df.agg({"pIa": "min"}).collect()[0][0]
     0.0
 
     # Note that we can also specify a model
-    >>> args = [F.col(i) for i in what_prefix] + [F.col('cdsxmatch'), F.col('ndethist')] + [F.lit(model_path_sigmoid)]
+    >>> args = [F.col(i) for i in what_prefix]
+    >>> args += [F.col('cdsxmatch'), F.col('candidate.ndethist')]
+    >>> args += [F.lit(model_path_sigmoid)]
     >>> df = df.withColumn('pIa', rfscore_sigmoid_full(*args))
 
     >>> df.agg({"pIa": "min"}).collect()[0][0]

--- a/fink_science/random_forest_snia/processor.py
+++ b/fink_science/random_forest_snia/processor.py
@@ -102,13 +102,14 @@ def rfscore_sigmoid_full(jd, fid, magpsf, sigmapsf, cdsxmatch, ndethist, model=N
     """
     # Flag empty alerts
     mask = magpsf.apply(lambda x: np.sum(np.array(x) == np.array(x))) > 3
-    if len(jd[mask]) == 0:
-        return pd.Series(np.zeros(len(jd), dtype=float))
 
     mask *= (ndethist.astype(int) <= 20)
 
     list_of_sn_host = return_list_of_sn_host()
     mask *= cdsxmatch.apply(lambda x: x in list_of_sn_host)
+
+    if len(jd[mask]) == 0:
+        return pd.Series(np.zeros(len(jd), dtype=float))
 
     # add an exploded column with SNID
     df_tmp = pd.DataFrame.from_dict(

--- a/fink_science/random_forest_snia/processor.py
+++ b/fink_science/random_forest_snia/processor.py
@@ -35,6 +35,8 @@ def rfscore_sigmoid_full(jd, fid, magpsf, sigmapsf, cdsxmatch, ndethist, model=N
     """ Return the probability of an alert to be a SNe Ia using a Random
     Forest Classifier (sigmoid fit).
 
+    You need to run the SIMBAD crossmatch before.
+
     Parameters
     ----------
     jd: Spark DataFrame Column
@@ -58,10 +60,14 @@ def rfscore_sigmoid_full(jd, fid, magpsf, sigmapsf, cdsxmatch, ndethist, model=N
 
     Examples
     ----------
+    >>> from fink_science.xmatch.processor import cdsxmatch
     >>> from fink_science.utilities import concat_col
     >>> from pyspark.sql import functions as F
 
     >>> df = spark.read.load(ztf_alert_sample)
+
+    >>> colnames = [df['objectId'], df['candidate.ra'], df['candidate.dec']]
+    >>> df = df.withColumn('cdsxmatch', cdsxmatch(*colnames))
 
     # Required alert columns
     >>> what = ['jd', 'fid', 'magpsf', 'sigmapsf']

--- a/fink_science/snn/processor.py
+++ b/fink_science/snn/processor.py
@@ -25,11 +25,12 @@ import os
 from fink_science import __file__
 from fink_science.conversion import mag2fluxcal_snana
 from fink_science.snn.utilities import reformat_to_df
+from fink_science.snn.utilities import return_list_of_sn_host
 
 from fink_science.tester import spark_unit_tests
 
 @pandas_udf(DoubleType(), PandasUDFType.SCALAR)
-def snn_ia(candid, jd, fid, magpsf, sigmapsf, model_name, model_ext=None) -> pd.Series:
+def snn_ia(candid, jd, fid, magpsf, sigmapsf, roid, cdsxmatch, jdstarthist, model_name, model_ext=None) -> pd.Series:
     """ Compute probabilities of alerts to be SN Ia using SuperNNova
 
     Parameters
@@ -56,10 +57,16 @@ def snn_ia(candid, jd, fid, magpsf, sigmapsf, model_name, model_ext=None) -> pd.
 
     Examples
     ----------
+    >>> from fink_science.xmatch.processor import cdsxmatch
+    >>> from fink_science.asteroids.processor import roid_catcher
     >>> from fink_science.utilities import concat_col
     >>> from pyspark.sql import functions as F
 
     >>> df = spark.read.load(ztf_alert_sample)
+
+    # Add SIMBAD field
+    >>> colnames = [df['objectId'], df['candidate.ra'], df['candidate.dec']]
+    >>> df = df.withColumn('cdsxmatch', cdsxmatch(*colnames))
 
     # Required alert columns
     >>> what = ['jd', 'fid', 'magpsf', 'sigmapsf']
@@ -72,15 +79,26 @@ def snn_ia(candid, jd, fid, magpsf, sigmapsf, model_name, model_ext=None) -> pd.
     >>> for colname in what:
     ...    df = concat_col(df, colname, prefix=prefix)
 
+    # Add SSO field
+    >>> args_roid = [
+    ...    'cjd', 'cmagpsf',
+    ...    'candidate.ndethist', 'candidate.sgscore1',
+    ...    'candidate.ssdistnr', 'candidate.distpsnr1']
+    >>> df = df.withColumn('roid', roid_catcher(*args_roid))
+
     # Perform the fit + classification (default model)
-    >>> args = ['candid', 'cjd', 'cfid', 'cmagpsf', 'csigmapsf', F.lit('snn_snia_vs_nonia')]
+    >>> args = ['candid', 'cjd', 'cfid', 'cmagpsf', 'csigmapsf']
+    >>> args += [F.col('roid'), F.col('cdsxmatch'), F.col('candidate.jdstarthist')]
+    >>> args += [F.lit('snn_snia_vs_nonia')]
     >>> df = df.withColumn('pIa', snn_ia(*args))
 
     >>> df.agg({"pIa": "min"}).collect()[0][0] >= 0.0
     True
 
     # Note that we can also specify a model
-    >>> args = [F.col(i) for i in ['candid', 'cjd', 'cfid', 'cmagpsf', 'csigmapsf']] + [F.lit(''), F.lit(model_path)]
+    >>> args = [F.col(i) for i in ['candid', 'cjd', 'cfid', 'cmagpsf', 'csigmapsf']]
+    >>> args += [F.col('roid'), F.col('cdsxmatch'), F.col('candidate.jdstarthist')]
+    >>> args += [F.lit(''), F.lit(model_path)]
     >>> df = df.withColumn('pIa', snn_ia(*args))
 
     >>> df.agg({"pIa": "min"}).collect()[0][0] >= 0.0
@@ -89,6 +107,20 @@ def snn_ia(candid, jd, fid, magpsf, sigmapsf, model_name, model_ext=None) -> pd.
     >>> df.agg({"pIa": "max"}).collect()[0][0] < 1.0
     True
     """
+    # Flag empty alerts
+    mask = magpsf.apply(lambda x: np.sum(np.array(x) == np.array(x))) > 1
+
+    mask *= jd.apply(lambda x: float(x[-1])) - jdstarthist.astype(float) <= 90
+
+    mask *= roid.astype(int) != 3
+
+    list_of_sn_host = return_list_of_sn_host()
+    mask *= cdsxmatch.apply(lambda x: x in list_of_sn_host)
+
+    if len(jd[mask]) == 0:
+        return pd.Series(np.zeros(len(jd), dtype=float))
+
+
     if model_ext is not None:
         # take the first element of the Series
         model = model_ext.values[0]
@@ -100,8 +132,8 @@ def snn_ia(candid, jd, fid, magpsf, sigmapsf, model_name, model_ext=None) -> pd.
     # add an exploded column with SNID
     df_tmp = pd.DataFrame.from_dict(
         {
-            'jd': jd,
-            'SNID': [str(i) for i in candid.values]
+            'jd': jd[mask],
+            'SNID': [str(i) for i in candid[mask].values]
         }
     )
 
@@ -109,8 +141,8 @@ def snn_ia(candid, jd, fid, magpsf, sigmapsf, model_name, model_ext=None) -> pd.
 
     # compute flux and flux error
     data = [mag2fluxcal_snana(*args) for args in zip(
-        magpsf.explode(),
-        sigmapsf.explode())]
+        magpsf[mask].explode(),
+        sigmapsf[mask].explode())]
     flux, error = np.transpose(data)
 
     # make a Pandas DataFrame with exploded series
@@ -119,7 +151,7 @@ def snn_ia(candid, jd, fid, magpsf, sigmapsf, model_name, model_ext=None) -> pd.
         'MJD': df_tmp['jd'],
         'FLUXCAL': flux,
         'FLUXCALERR': error,
-        'FLT': fid.explode().replace({1: 'g', 2: 'r'})
+        'FLT': fid[mask].explode().replace({1: 'g', 2: 'r'})
     })
 
     # Compute predictions
@@ -128,10 +160,14 @@ def snn_ia(candid, jd, fid, magpsf, sigmapsf, model_name, model_ext=None) -> pd.
     # Reformat and re-index
     preds_df = reformat_to_df(pred_probs, ids=ids)
     preds_df.index = preds_df.SNID
-    ia = preds_df.reindex([str(i) for i in candid.values])
+
+    # Take only probabilities to be Ia
+    to_return = np.zeros(len(jd), dtype=float)
+    ia = preds_df.reindex([str(i) for i in candid[mask].values])
+    to_return[mask] = ia.prob_class0.values
 
     # return probabilities to be Ia
-    return ia.prob_class0
+    return pd.Series(to_return)
 
 
 if __name__ == "__main__":

--- a/fink_science/snn/processor.py
+++ b/fink_science/snn/processor.py
@@ -120,7 +120,6 @@ def snn_ia(candid, jd, fid, magpsf, sigmapsf, roid, cdsxmatch, jdstarthist, mode
     if len(jd[mask]) == 0:
         return pd.Series(np.zeros(len(jd), dtype=float))
 
-
     if model_ext is not None:
         # take the first element of the Series
         model = model_ext.values[0]

--- a/fink_science/snn/utilities.py
+++ b/fink_science/snn/utilities.py
@@ -17,6 +17,42 @@ import pandas as pd
 
 from fink_science.tester import regular_unit_tests
 
+def return_list_of_sn_host():
+    """ Return potential SN host names
+
+    This includes:
+    - List of object names in SIMBAD that would correspond to extra-galactic object
+    - Unknown objects
+    - objects with failed crossmatch
+
+    In practice, this exclude galactic objects from SIMBAD.
+
+    """
+    list_simbad_galaxies = [
+        "galaxy",
+        "Galaxy",
+        "EmG",
+        "Seyfert",
+        "Seyfert_1",
+        "Seyfert_2",
+        "BlueCompG",
+        "StarburstG",
+        "LSB_G",
+        "HII_G",
+        "High_z_G",
+        "GinPair",
+        "GinGroup",
+        "BClG",
+        "GinCl",
+        "PartofG",
+    ]
+
+    keep_cds = \
+        ["Unknown", "Candidate_SN*", "SN", "Transient", "Fail"] + \
+        list_simbad_galaxies
+
+    return keep_cds
+
 def reformat_to_df(pred_probs, ids=None):
     """ Reformat supernnova predictions to DataFrame.
 


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #127 

## If this is a new release, did you issue the corresponding schema in fink-client?

Not a release.

## What changes were proposed in this pull request?

Filtering of irrelevant sources is done before processing. The filtering is in line with what is in `fink-filters`. We show below some benchmark using:

```python
df.withColumn('field', module(*args)).select('field').toPandas()
```

Note that `df` is already in-memory (so we trace actual module operations, and the final `reduce`, but not the data loading time).

![perf_science_modules](https://user-images.githubusercontent.com/20426972/148606878-4652259c-784b-43ea-a2a4-a519557a78cb.png)

Note that the rate for `All` does not correspond to the `1/(sum_i 1/rate_i)`, but we ran all modules at once. The former is faster in practice as Spark does some optimization in the background (and there is only one `reduce` operation obviously).

## How was this patch tested?

Manually and I checked classification at the end remains the same