### PR TITLE
set default kn model as partial

### DIFF
--- a/fink_science/kilonova/processor.py
+++ b/fink_science/kilonova/processor.py
@@ -55,7 +55,7 @@ def knscore(jd, fid, magpsf, sigmapsf, jdstarthist, cdsxmatch, ndethist, model_n
     model_name: str
         Nome of the model to be fetched from the kndetect package.
         supported options: "complete.pkl", "partial.pkl"
-        deault is "complete.pkl" (model trained for complete light curves)
+        deault is "partial.pkl" (model trained for complete light curves)
 
     Returns
     ----------
@@ -147,7 +147,7 @@ def knscore(jd, fid, magpsf, sigmapsf, jdstarthist, cdsxmatch, ndethist, model_n
 
     # Load pre-trained model
     if model_name is None:
-        model = load_classifier("complete.pkl")
+        model = load_classifier("partial.pkl")
     else:
         model = load_classifier(model_name.values[0])
 


### PR DESCRIPTION
As pointed out by @JulienPeloton, #169 only updates the test suite.
This PR is supposed to update the default model used by the broker to the one trained on partial lightcurves.