### PR TITLE
Upgrade to sklearn 1.0.2

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -43,5 +43,7 @@ jobs:
     - name: Run test suites
       run: |
         pip install fink-utils --upgrade
+        pip install scikit-learn==1.0.2
+        pip install git+https://github.com/b-biswas/kndetect --upgrade
         ./run_tests.sh
         curl -s https://codecov.io/bash | bash


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #82 

## If this is a new release, did you issue the corresponding schema in fink-client?

Need.

## What changes were proposed in this pull request?

Upgrade kndetect to use sklearn 1.0.2, and push AL model trained with sklearn 1.0.2

## How was this patch tested?

CI