### PR TITLE
[Elasticc] Limit lightcurve duration to 25 days for classification of early Ia

### DIFF
--- a/fink_science/random_forest_snia/processor.py
+++ b/fink_science/random_forest_snia/processor.py
@@ -333,6 +333,11 @@ def rfscore_sigmoid_elasticc(midPointTai, filterName, psFlux, psFluxErr, cdsxmat
     """
     mask = apply_selection_cuts_ztf(psFlux, nobs, cdsxmatch, maxndethist=100)
 
+    dt = midPointTai.apply(lambda x: np.max(x) - np.min(x))
+
+    # Maximum 25 days in the history
+    mask *= (dt <= 25)
+
     if len(midPointTai[mask]) == 0:
         return pd.Series(np.zeros(len(midPointTai), dtype=float))
 


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #197 

## If this is a new release, did you issue the corresponding schema in fink-client?

No

## What changes were proposed in this pull request?

Introduce a new cut that discard alerts varying from more than 25 days.

## How was this patch tested?

CI