### PR TITLE
[Elasticc] Fix bugs in the modified CATS processor

### DIFF
--- a/fink_science/cats/processor.py
+++ b/fink_science/cats/processor.py
@@ -146,8 +146,8 @@ def predict_nn(
     >>> args += [F.col('diaObject.mwebv'), F.col('diaObject.z_final'), F.col('diaObject.z_final_err')]
     >>> args += [F.col('diaObject.hostgal_zphot'), F.col('diaObject.hostgal_zphot_err')]
     >>> df = df.withColumn('preds', predict_nn(*args))
-    >>> df = df.withColumn('cbpf_class', F.col('preds.broad').getItem(0).astype('int'))
-    >>> df = df.withColumn('cbpf_max_prob', F.col('preds.broad').getItem(1))
+    >>> df = df.withColumn('cbpf_class', F.col('preds.broad_preds').getItem(0).astype('int'))
+    >>> df = df.withColumn('cbpf_max_prob', F.col('preds.broad_preds').getItem(1))
     >>> df.filter(df['cbpf_class'] == 0).count()
     39
     """


### PR DESCRIPTION
The processor now returns a DF with schema:

```
root
 |-- preds: struct (nullable = true)
 |    |-- broad_preds: array (nullable = true)
 |    |    |-- element: float (containsNull = true)
 |    |-- fine_preds: array (nullable = true)
 |    |    |-- element: float (containsNull = true)
```
where we have (class, max_prob) in each array.