### PR TITLE
[Anomaly] Remove measurements from negative subtraction

### DIFF
--- a/fink_science/ad_features/processor.py
+++ b/fink_science/ad_features/processor.py
@@ -78,6 +78,7 @@ def extract_features_ad_raw(
     jd,
     sigmapsf,
     cfid,
+    isdiffpos,
     oId
 ) -> pd.Series:
     """ Returns many features, extracted from measurments using light_curve package (https://github.com/light-curve/light-curve-python).
@@ -91,6 +92,9 @@ def extract_features_ad_raw(
         Magnitude from PSF-fit photometry, and 1-sigma error
     fid: Spark DataFrame Column
         Filter IDs (int)
+    isdiffpos: Spark DataFrame Column
+        't' or '1' => candidate is from positive (sci minus ref) subtraction;
+        'f' or '0' => candidate is from negative (ref minus sci) subtraction
     oId: Spark DataFrame Column
         Object IDs (str)
 
@@ -107,7 +111,7 @@ def extract_features_ad_raw(
     >>> df = spark.read.load(ztf_alert_sample)
 
     # Required alert columns, concatenated with historical data
-    >>> what = ['magpsf', 'jd', 'sigmapsf', 'fid']
+    >>> what = ['magpsf', 'jd', 'sigmapsf', 'fid', 'isdiffpos']
     >>> prefix = 'c'
     >>> what_prefix = [prefix + i for i in what]
     >>> for colname in what:
@@ -131,7 +135,10 @@ def extract_features_ad_raw(
 
     # Select only valid measurements (not upper limits)
     maskNotNone = magpsf == magpsf
-    mask = ~(np.isnan(magpsf) | np.isnan(sigmapsf)) & maskNotNone
+
+    # Select only positive subtraction (alert brighter than the template)
+    maskPosSub = np.array([i in ['t', '1'] for i in isdiffpos])
+    mask = ~(np.isnan(magpsf) | np.isnan(sigmapsf)) & maskNotNone & maskPosSub
 
     magpsf = magpsf[mask]
     sigmapsf = sigmapsf[mask]

--- a/fink_science/ad_features/test.py
+++ b/fink_science/ad_features/test.py
@@ -30,7 +30,14 @@ for name in names:
 
 result_features = []
 for index, dataset in enumerate(test_datasets):
-    result = processor.extract_features_ad_raw(dataset.mag, dataset.mjd, dataset.magerr, np.ones(len(dataset.mag)), index)
+    result = processor.extract_features_ad_raw(
+        dataset.mag,
+        dataset.mjd,
+        dataset.magerr,
+        np.ones(len(dataset.mag)),
+        np.ones(len(dataset.mag), dtype=str),
+        index
+    )
     result_features.append({
         lc_columns[i]: result[1][lc_columns[i]] for i in range(len(lc_columns))
     })

--- a/fink_science/anomaly_detection/processor.py
+++ b/fink_science/anomaly_detection/processor.py
@@ -95,7 +95,7 @@ def anomaly_score(lc_features) -> float:
     >>> df = spark.read.load(ztf_alert_sample)
 
     # Required alert columns, concatenated with historical data
-    >>> what = ['magpsf', 'jd', 'sigmapsf', 'fid']
+    >>> what = ['magpsf', 'jd', 'sigmapsf', 'fid', 'isdiffpos']
     >>> prefix = 'c'
     >>> what_prefix = [prefix + i for i in what]
     >>> for colname in what:
@@ -105,10 +105,10 @@ def anomaly_score(lc_features) -> float:
     >>> df = df.withColumn("anomaly_score", anomaly_score("lc_features"))
 
     >>> df.filter(df["anomaly_score"] < -0.5).count()
-    5
+    4
 
     >>> df.filter(df["anomaly_score"] == 0).count()
-    84
+    63
 
     """
 


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #296 

## What changes were proposed in this pull request?

We now keep only measurements with positive subtraction (alert brighter than the template), and reject measurements with negative subtraction:

```python
# Select only positive subtraction (alert brighter than the template)
maskPosSub = np.array([i in ['t', '1'] for i in isdiffpos])
```

## How was this patch tested?

CI