### PR TITLE
Add example for crossmatching with the SPICY catalog

### DIFF
--- a/fink_science/xmatch/processor.py
+++ b/fink_science/xmatch/processor.py
@@ -240,7 +240,7 @@ def xmatch_cds(
     ...     catalogname="vizier:J/ApJS/254/33/table1",
     ...     distmaxarcsec=1.2,
     ...     cols_out=['SPICY', 'class'],
-    ...     types=['string', 'string'])
+    ...     types=['int', 'string'])
     >>> 'SPICY' in df_spicys.columns
     True
     """

--- a/fink_science/xmatch/processor.py
+++ b/fink_science/xmatch/processor.py
@@ -233,6 +233,16 @@ def xmatch_cds(
     ...     types=['string'])
     >>> 'Type' in df_vsx.columns
     True
+
+    # SPICY
+    >>> df_spicy = xmatch_cds(
+    ...     df,
+    ...     catalogname="vizier:J/ApJS/254/33/table1",
+    ...     distmaxarcsec=1.2,
+    ...     cols_out=['SPICY', 'class'],
+    ...     types=['string', 'string'])
+    >>> 'SPICY' in df_spicys.columns
+    True
     """
     df_out = df.withColumn(
         'xmatch',

--- a/fink_science/xmatch/processor.py
+++ b/fink_science/xmatch/processor.py
@@ -241,7 +241,7 @@ def xmatch_cds(
     ...     distmaxarcsec=1.2,
     ...     cols_out=['SPICY', 'class'],
     ...     types=['int', 'string'])
-    >>> 'SPICY' in df_spicys.columns
+    >>> 'SPICY' in df_spicy.columns
     True
     """
     df_out = df.withColumn(


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #367 

```python
>>> df = spark.read.format('parquet').load('archive/science/year=2023/month=01')
>>> df = xmatch_cds(
  df, 
  catalogname='vizier:J/ApJS/254/33/table1', 
  distmaxarcsec=1.2, 
  cols_out=['SPICY', 'class'],
  types=['int', 'string']
)
>>> df.select(['objectId', 'cdsxmatch', 'SPICY', 'class']).filter(~df['SPICY'].isNull()).show()
+------------+-------------+------+--------+                                    
|    objectId|    cdsxmatch| SPICY|   class|
+------------+-------------+------+--------+
|ZTF18aazkywa|      Unknown| 93722|      FS|
|ZTF18aazmeet|YSO_Candidate|103640| ClassII|
|ZTF18aazkywa|      Unknown| 93722|      FS|
|ZTF18adkelal|          YSO|103334| ClassII|
|ZTF18aazmeet|YSO_Candidate|103640| ClassII|
|ZTF18aaugvnd|      Unknown|103191| ClassII|
|ZTF18aatqgsq|          YSO|103433| ClassII|
|ZTF18abjxkld|      Unknown|102435|ClassIII|
|ZTF18abcdskj|          YSO|117444| ClassII|
|ZTF18aazwmin|          YSO|116974| ClassII|
|ZTF17aabupud|          YSO|116833| ClassII|
|ZTF18abchhzs|          YSO|116951| ClassII|
|ZTF18abodvrt|          YSO|117445|      FS|
|ZTF18aazgcla|          YSO|116874|  ClassI|
|ZTF18ablomsi|      Unknown| 88534| ClassII|
|ZTF18aazkywa|      Unknown| 93722|      FS|
|ZTF18aaynseb|YSO_Candidate| 94450| ClassII|
|ZTF18aazroen|        TTau*| 88630| ClassII|
|ZTF18abkjxpe|      Unknown| 86591| ClassII|
|ZTF18abfaepx|      Unknown| 94723| ClassII|
+------------+-------------+------+--------+
only showing top 20 rows


```