### PR TITLE
Remove i-band processing from ad_features

### DIFF
--- a/fink_science/ad_features/processor.py
+++ b/fink_science/ad_features/processor.py
@@ -135,7 +135,7 @@ def extract_features_ad_raw(
     ...    assert len(row['lc_features'][1]) == 26
 
     # check the processing on i-band
-    >>> df = spark.read.format('parquet').load(ztf_alert_with_band)
+    >>> df = spark.read.format('parquet').load(ztf_alert_with_i_band)
 
     # Required alert columns, concatenated with historical data
     >>> what = ['magpsf', 'jd', 'sigmapsf', 'fid', 'distnr', 'magnr', 'sigmagnr', 'isdiffpos']
@@ -248,8 +248,8 @@ if __name__ == "__main__":
     globs["ztf_alert_sample"] = ztf_alert_sample
     del globs["extract_features_ad_raw"]
 
-    ztf_alert_with_band = 'file://{}/data/alerts/20240606_iband_history.parquet'.format(path)
-    globs["ztf_alert_with_band"] = ztf_alert_with_band
+    ztf_alert_with_i_band = 'file://{}/data/alerts/20240606_iband_history.parquet'.format(path)
+    globs["ztf_alert_with_i_band"] = ztf_alert_with_i_band
 
     # Run the test suite
     spark_unit_tests(globs)

--- a/fink_science/ad_features/processor.py
+++ b/fink_science/ad_features/processor.py
@@ -133,6 +133,23 @@ def extract_features_ad_raw(
     >>> for row in df.take(10):
     ...    assert len(row['lc_features']) == len(np.unique(row['cfid']))
     ...    assert len(row['lc_features'][1]) == 26
+
+    # check the processing on i-band
+    >>> df = spark.read.format('parquet').load(ztf_alert_with_band)
+
+    # Required alert columns, concatenated with historical data
+    >>> what = ['magpsf', 'jd', 'sigmapsf', 'fid', 'distnr', 'magnr', 'sigmagnr', 'isdiffpos']
+    >>> prefix = 'c'
+    >>> what_prefix = [prefix + i for i in what]
+    >>> for colname in what:
+    ...    df = concat_col(df, colname, prefix=prefix)
+
+    >>> cols = ['cmagpsf', 'cjd', 'csigmapsf', 'cfid', 'objectId', 'cdistnr', 'cmagnr', 'csigmagnr', 'cisdiffpos']
+    >>> df = df.withColumn('lc_features', extract_features_ad(*cols))
+
+    >>> for row in df.take(10):
+    ...    assert len(row['lc_features']) == len(np.unique(row['cfid'])) - 1
+    ...    assert 3 not in row['lc_features'].keys()
     """
 
     cfid = np.asarray(cfid, "int32")
@@ -144,6 +161,10 @@ def extract_features_ad_raw(
     extractor = create_extractor()
 
     passbands = np.unique(cfid)
+
+    # keep only g and/or r -- see #393
+    maskFilter = passbands <= 2
+    passbands = passbands[maskFilter]
 
     # Select only valid measurements (not upper limits)
     maskNotNone = magpsf == magpsf
@@ -226,6 +247,9 @@ if __name__ == "__main__":
     ztf_alert_sample = 'file://{}/data/alerts/datatest'.format(path)
     globs["ztf_alert_sample"] = ztf_alert_sample
     del globs["extract_features_ad_raw"]
+
+    ztf_alert_with_band = 'file://{}/data/alerts/20240606_iband_history.parquet'.format(path)
+    globs["ztf_alert_with_band"] = ztf_alert_with_band
 
     # Run the test suite
     spark_unit_tests(globs)

--- a/fink_science/agn/processor.py
+++ b/fink_science/agn/processor.py
@@ -134,6 +134,24 @@ def agn_ztf(objectId, jd, magpsf, sigmapsf, fid, ra, dec):
     >>> df_agn = df.withColumn('proba', agn_ztf(*args))
     >>> df_agn.filter(df_agn['proba'] != 0.0).count()
     145
+
+    # Verify the code executes if i-band is present in the history
+    >>> df = spark.read.load(ztf_alert_with_i_band)
+
+    # Use for creating temp name
+    >>> prefix = 'c'
+    >>> what_prefix = [prefix + i for i in what]
+
+    # Append temp columns with historical + current measurements
+    >>> for colname in what:
+    ...    df = concat_col(df, colname, prefix=prefix)
+
+    # Perform the fit + classification (default model)
+    >>> args = ['objectId'] + [F.col(i) for i in what_prefix]
+    >>> args += ['candidate.ra', 'candidate.dec']
+    >>> df_agn = df.withColumn('proba', agn_ztf(*args))
+    >>> df_agn.filter(df_agn['proba'] != 0.0).count()
+    145
     """
 
     data = pd.DataFrame(
@@ -160,6 +178,9 @@ if __name__ == "__main__":
 
     ztf_alert_sample = 'file://{}/data/alerts/datatest'.format(path)
     globs["ztf_alert_sample"] = ztf_alert_sample
+
+    ztf_alert_with_i_band = 'file://{}/data/alerts/20240606_iband_history.parquet'.format(path)
+    globs["ztf_alert_with_i_band"] = ztf_alert_with_i_band
 
     # Run the test suite
     spark_unit_tests(globs)

--- a/fink_science/agn/processor.py
+++ b/fink_science/agn/processor.py
@@ -151,7 +151,7 @@ def agn_ztf(objectId, jd, magpsf, sigmapsf, fid, ra, dec):
     >>> args += ['candidate.ra', 'candidate.dec']
     >>> df_agn = df.withColumn('proba', agn_ztf(*args))
     >>> df_agn.filter(df_agn['proba'] != 0.0).count()
-    145
+    69
     """
 
     data = pd.DataFrame(

--- a/fink_science/anomaly_detection/processor.py
+++ b/fink_science/anomaly_detection/processor.py
@@ -103,7 +103,7 @@ def anomaly_score(lc_features, model_type="AADForest"):
     >>> df = df.withColumn("anomaly_score", anomaly_score("lc_features"))
 
     >>> df.filter(df["anomaly_score"] < 0).count()
-    108
+    121
     """
 
     path = os.path.dirname(os.path.abspath(__file__))

--- a/fink_science/anomaly_detection/processor.py
+++ b/fink_science/anomaly_detection/processor.py
@@ -87,6 +87,23 @@ def anomaly_score(lc_features, model_type="AADForest"):
 
     >>> df.filter(df["anomaly_score"] == 0).count()
     84
+
+    # Check the robustness of the code when i-band is present
+    >>> df = spark.read.load(ztf_alert_with_i_band)
+
+    # Required alert columns, concatenated with historical data
+    >>> what = ['magpsf', 'jd', 'sigmapsf', 'fid', 'distnr', 'magnr', 'sigmagnr', 'isdiffpos']
+    >>> prefix = 'c'
+    >>> what_prefix = [prefix + i for i in what]
+    >>> for colname in what:
+    ...    df = concat_col(df, colname, prefix=prefix)
+
+    >>> cols = ['cmagpsf', 'cjd', 'csigmapsf', 'cfid', 'objectId', 'cdistnr', 'cmagnr', 'csigmagnr', 'cisdiffpos']
+    >>> df = df.withColumn('lc_features', extract_features_ad(*cols))
+    >>> df = df.withColumn("anomaly_score", anomaly_score("lc_features"))
+
+    >>> df.filter(df["anomaly_score"] < 0).count()
+    108
     """
 
     path = os.path.dirname(os.path.abspath(__file__))
@@ -152,6 +169,9 @@ if __name__ == "__main__":
     path = os.path.dirname(os.path.abspath(__file__))
     ztf_alert_sample = 'file://{}/data/alerts/datatest'.format(path)
     globs["ztf_alert_sample"] = ztf_alert_sample
+
+    ztf_alert_with_i_band = 'file://{}/data/alerts/20240606_iband_history.parquet'.format(path)
+    globs["ztf_alert_with_i_band"] = ztf_alert_with_i_band
 
     # Run the test suite
     spark_unit_tests(globs)

--- a/fink_science/fast_transient_rate/processor.py
+++ b/fink_science/fast_transient_rate/processor.py
@@ -67,7 +67,18 @@ def get_last_alert(
     jdstarthist5sigma = cjd[idx_first_mag[0]]
 
     for idx in range(len(cfid) - 2, -1, -1):
-        if cfid[idx] == fid:
+        if cfid[idx] > 2:
+            # neither g nor r for ZTF
+            # TODO: change the logic for LSST
+            return [
+                float("nan"),
+                float("nan"),
+                float("nan"),
+                float("nan"),
+                jdstarthist5sigma,
+            ]
+
+        elif cfid[idx] == fid:
             if cmagpsf[idx] is None:
                 return [
                     float("nan"),
@@ -398,6 +409,12 @@ def fast_transient_module(spark_df, N, seed=None):
     >>> df = fast_transient_module(df, 10000, 2023)
     >>> df.filter(abs(df.mag_rate) > 0.2).count()
     190
+
+    # check robustness for i-band
+    >>> df = spark.read.format('parquet').load(ztf_alert_with_i_band)
+    >>> df = fast_transient_module(df, 10000, 2023)
+    >>> df.filter(abs(df.mag_rate) > 0.2).count()
+    ...
     """
     cols_before = spark_df.columns
 
@@ -437,6 +454,9 @@ if __name__ == "__main__":
     path = os.path.dirname(__file__)
     ztf_alert_sample = "file://{}/data/alerts/datatest".format(path)
     globs["ztf_alert_sample"] = ztf_alert_sample
+
+    ztf_alert_with_i_band = 'file://{}/data/alerts/20240606_iband_history.parquet'.format(path)
+    globs["ztf_alert_with_i_band"] = ztf_alert_with_i_band
 
     # Run the test suite
     spark_unit_tests(globs)

--- a/fink_science/fast_transient_rate/processor.py
+++ b/fink_science/fast_transient_rate/processor.py
@@ -414,7 +414,7 @@ def fast_transient_module(spark_df, N, seed=None):
     >>> df = spark.read.format('parquet').load(ztf_alert_with_i_band)
     >>> df = fast_transient_module(df, 10000, 2023)
     >>> df.filter(abs(df.mag_rate) > 0.2).count()
-    ...
+    119
     """
     cols_before = spark_df.columns
 

--- a/fink_science/kilonova/processor.py
+++ b/fink_science/kilonova/processor.py
@@ -125,7 +125,7 @@ def knscore(jd, fid, magpsf, sigmapsf, jdstarthist, cdsxmatch, ndethist, model_n
     >>> df = df.withColumn('pKNe', knscore(*args))
 
     >>> df.filter(df['pKNe'] > 0.5).count()
-    0
+    6
     """
     # Flag empty alerts
     mask = magpsf.apply(lambda x: np.sum(np.array(x) == np.array(x))) > 1

--- a/fink_science/kilonova/processor.py
+++ b/fink_science/kilonova/processor.py
@@ -125,6 +125,7 @@ def knscore(jd, fid, magpsf, sigmapsf, jdstarthist, cdsxmatch, ndethist, model_n
     >>> df = df.withColumn('pKNe', knscore(*args))
 
     >>> df.filter(df['pKNe'] > 0.5).count()
+    0
     """
     # Flag empty alerts
     mask = magpsf.apply(lambda x: np.sum(np.array(x) == np.array(x))) > 1

--- a/fink_science/kilonova/processor.py
+++ b/fink_science/kilonova/processor.py
@@ -125,7 +125,7 @@ def knscore(jd, fid, magpsf, sigmapsf, jdstarthist, cdsxmatch, ndethist, model_n
     >>> df = df.withColumn('pKNe', knscore(*args))
 
     >>> df.filter(df['pKNe'] > 0.5).count()
-    6
+    0
     """
     # Flag empty alerts
     mask = magpsf.apply(lambda x: np.sum(np.array(x) == np.array(x))) > 1

--- a/fink_science/kilonova/processor.py
+++ b/fink_science/kilonova/processor.py
@@ -107,6 +107,24 @@ def knscore(jd, fid, magpsf, sigmapsf, jdstarthist, cdsxmatch, ndethist, model_n
 
     >>> df.filter(df['pKNe'] > 0.5).count()
     1
+
+    # check robustness wrt i-band
+    >>> df = spark.read.load(ztf_alert_with_i_band)
+    >>> df = xmatch_cds(df)
+
+    # Required alert columns
+    >>> what = ['jd', 'fid', 'magpsf', 'sigmapsf']
+    >>> prefix = 'c'
+    >>> what_prefix = [prefix + i for i in what]
+    >>> for colname in what:
+    ...    df = concat_col(df, colname, prefix=prefix)
+
+    # Perform the fit + classification (default model)
+    >>> args = [F.col(i) for i in what_prefix]
+    >>> args += [F.col('candidate.jdstarthist'), F.col('cdsxmatch'), F.col('candidate.ndethist')]
+    >>> df = df.withColumn('pKNe', knscore(*args))
+
+    >>> df.filter(df['pKNe'] > 0.5).count()
     """
     # Flag empty alerts
     mask = magpsf.apply(lambda x: np.sum(np.array(x) == np.array(x))) > 1
@@ -288,6 +306,9 @@ if __name__ == "__main__":
 
     ztf_alert_sample = 'file://{}/data/alerts/datatest'.format(path)
     globs["ztf_alert_sample"] = ztf_alert_sample
+
+    ztf_alert_with_i_band = 'file://{}/data/alerts/20240606_iband_history.parquet'.format(path)
+    globs["ztf_alert_with_i_band"] = ztf_alert_with_i_band
 
     # Run the test suite
     spark_unit_tests(globs)

--- a/fink_science/random_forest_snia/processor.py
+++ b/fink_science/random_forest_snia/processor.py
@@ -195,7 +195,7 @@ def rfscore_sigmoid_full(
     >>> df = df.withColumn('pIa', rfscore_sigmoid_full(*args))
 
     >>> df.filter(df['pIa'] > 0.5).count()
-    6
+    0
     """
     mask = apply_selection_cuts_ztf(magpsf, ndethist, cdsxmatch)
 

--- a/fink_science/random_forest_snia/processor.py
+++ b/fink_science/random_forest_snia/processor.py
@@ -177,6 +177,25 @@ def rfscore_sigmoid_full(
 
     >>> df.agg({"pIaAL": "max"}).collect()[0][0] < 1.0
     True
+
+    # check robustness wrt i-band
+    >>> df = spark.read.load(ztf_alert_with_i_band)
+    >>> df = xmatch_cds(df)
+
+    # Required alert columns
+    >>> what = ['jd', 'fid', 'magpsf', 'sigmapsf']
+    >>> prefix = 'c'
+    >>> what_prefix = [prefix + i for i in what]
+    >>> for colname in what:
+    ...    df = concat_col(df, colname, prefix=prefix)
+
+    # Perform the fit + classification (default model)
+    >>> args = [F.col(i) for i in what_prefix]
+    >>> args += [F.col('cdsxmatch'), F.col('candidate.ndethist')]
+    >>> df = df.withColumn('pIa', rfscore_sigmoid_full(*args))
+
+    >>> df.filter(df['pIa'] > 0.5).count()
+    6
     """
     mask = apply_selection_cuts_ztf(magpsf, ndethist, cdsxmatch)
 
@@ -562,6 +581,9 @@ if __name__ == "__main__":
 
     model_path_al_loop = '{}/data/models/for_al_loop/model_20231009.pkl'.format(path)
     globs["model_path_al_loop"] = model_path_al_loop
+
+    ztf_alert_with_i_band = 'file://{}/data/alerts/20240606_iband_history.parquet'.format(path)
+    globs["ztf_alert_with_i_band"] = ztf_alert_with_i_band
 
     # Run the test suite
     spark_unit_tests(globs)

--- a/fink_science/snn/processor.py
+++ b/fink_science/snn/processor.py
@@ -168,7 +168,7 @@ def snn_ia(candid, jd, fid, magpsf, sigmapsf, roid, cdsxmatch, jdstarthist, mode
     >>> df = df.withColumn('pIa', snn_ia(*args))
 
     >>> df.filter(df['pIa'] > 0.5).count()
-    0
+    13
     """
     mask = apply_selection_cuts_ztf(magpsf, cdsxmatch, jd, jdstarthist, roid)
 


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #393 

## What changes were proposed in this pull request?

Update all science module to discard i-band from the history, but keep processing other bands. A new dataset with `i-band` in the history has been added.

- [x] ad_features
- [x] agn (already handled in `fe.transform_data`) 
- [x] Anomaly detection (already handled)
- [x] Fast transient
- [x] KNe (already handled)
- [x] Microlensing (already handled)
- [x] Early SN Ia ([already handled externally](https://github.com/emilleishida/fink_sn_activelearning/blob/6e10a2aa0218d78c18ff17e86626ae6056b6fca3/actsnfink/classifier_sigmoid.py#L377C1-L377C30))
- [x] SNN (already handled via the model metadata)
- [ ] ...

## How was this patch tested?

CI
