### PR TITLE
Add light travel correction for ssHG1G2

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -43,6 +43,7 @@ jobs:
 
     - name: Run test suites
       run: |
+        pip install fink-utils==0.29.7
         rm -f /tmp/forest_*.onnx
         ./run_tests.sh
         curl -s https://codecov.io/bash | bash

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -43,7 +43,6 @@ jobs:
 
     - name: Run test suites
       run: |
-        pip install fink-utils==0.29.7
         rm -f /tmp/forest_*.onnx
         ./run_tests.sh
         curl -s https://codecov.io/bash | bash


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #457 

## If this is a new release, did you issue the corresponding schema in fink-client?
no

## What changes were proposed in this pull request?

Correct for the fact that light has finite speed when estimating parameters of the ssHG1G2 model.


## How was this patch tested?

CI. Note that tests will fail until `fink-utils` release 0.29.7 is out.