### PR TITLE
Add default tns column if the xmatch is skipped

### DIFF
--- a/fink_science/xmatch/processor.py
+++ b/fink_science/xmatch/processor.py
@@ -329,6 +329,7 @@ def xmatch_tns(df, distmaxarcsec=1.5, tns_raw_output=""):
         else:
             _LOG.warning("TNS_API_MARKER and TNS_API_KEY are not defined as env var in the master.")
             _LOG.warning("Skipping crossmatch with TNS.")
+            df = df.withColumn("tns", F.lit(""))
             return df
     else:
         pdf_tns = pd.read_parquet(os.path.join(tns_raw_output, 'tns_raw.parquet'))


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #465 

## If this is a new release, did you issue the corresponding schema in fink-client?

n/a

## What changes were proposed in this pull request?

Add the `tns` column regardless of the success of the xmatch.

## How was this patch tested?

CI