### PR TITLE
Update authors list in hostless detection powerspectrum file

### DIFF
--- a/fink_science/ztf/hostless_detection/powerspectrum.py
+++ b/fink_science/ztf/hostless_detection/powerspectrum.py
@@ -1,5 +1,5 @@
 # Copyright 2024 AstroLab Software
-# Author: R. Durgesh
+# Author: E. E. Hayes, R. Durgesh
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
I just noticed that Erin's name is missing in power spectrum analysis file. She implemented power spectrum analysis methods, so her name should be added.