### PR TITLE
[SSOFT] Keep only objects with same number of observations and ephemerides

### DIFF
--- a/fink_science/ztf/ssoft/processor.py
+++ b/fink_science/ztf/ssoft/processor.py
@@ -700,6 +700,7 @@ def build_the_ssoft(
     df = (
         df.withColumn("ephemmeasurements", F.size(df["Phase"]))
         .filter(F.col("ephemmeasurements") >= nmin)
+        .filter(F.size("cmagpsf") == F.size("Phase"))
         .repartition(nparts)
         .cache()
     )


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #591 

## What changes were proposed in this pull request?

Discard objects that have less ephemerides than observations (can happen if name is not resolved properly).

## How was this patch tested?

Manual