### PR TITLE
[Hostless] replace -99 by None

### DIFF
--- a/fink_science/rubin/hostless_detection/processor.py
+++ b/fink_science/rubin/hostless_detection/processor.py
@@ -76,12 +76,12 @@ def run_potential_hostless(
     ...         df["cutoutScience"],
     ...         df["cutoutTemplate"],
     ...         df["ssSource.ssObjectId"]))
-    >>> df.filter(df.elephant_kstest.kstest_science >= 0).count()
+    >>> df.filter(df.elephant_kstest.kstest_science.isNotNull()).count()
     0
-    >>> df.filter(df.elephant_kstest.kstest_science <= 0).count()
+    >>> df.filter(df.elephant_kstest.kstest_science.isNull()).count()
     25
     """
-    default_result = {"kstest_science": -99, "kstest_template": -99}
+    default_result = {"kstest_science": None, "kstest_template": None}
     kstest_results = []
     hostless_science_class = HostLessExtragalacticRubin(CONFIGS_BASE)
     for index in range(cutoutScience.shape[0]):


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes
- #626 

## What changes were proposed in this pull request?

This PR replace default values for the hostless module. The old values were `-99`, replaced by `None`, which will translate into massive compression in the DB.

## How was this patch tested?

CI