### PR TITLE
[Rubin] Define the return types for mangrove fields

### DIFF
--- a/fink_science/rubin/xmatch/utils.py
+++ b/fink_science/rubin/xmatch/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 AstroLab Software
+# Copyright 2019-2026 AstroLab Software
 # Author: Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +26,7 @@ import astropy.units as u
 from fink_science.tester import regular_unit_tests
 
 MANGROVE_COLS = ["HyperLEDA_name", "2MASS_name", "lum_dist", "ang_dist"]
+MAGROVE_TYPES = ["string", "string", "float", "float"]
 
 
 @profile


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes
- #628 

## What changes were proposed in this pull request?

Expose mangrove types to be used in `fink_broker.rubin.science`

## How was this patch tested?

Docker