### PR TITLE
[CATS] Return default predictions in case of no LC. Set verbosity to 0.

### DIFF
--- a/fink_science/rubin/cats/processor.py
+++ b/fink_science/rubin/cats/processor.py
@@ -111,8 +111,14 @@ def predict_nn(
 
     # check size of output
     """
+    preds = pd.Series([
+        [0.0] * len(CATS_CLASS_DICT) for i in range(len(midpointMjdTai))
+    ])
     # at least 2 points.
     mask = midpointMjdTai.apply(lambda x: len(x) > 1)
+
+    if mask.sum() == 0:
+        return preds
 
     filter_dict = {"u": 1, "g": 2, "r": 3, "i": 4, "z": 5, "y": 6}
 
@@ -156,14 +162,11 @@ def predict_nn(
 
     NN = tf.keras.Model(inp, out)
 
-    preds = NN.predict([lc])
+    valid_preds = NN.predict([lc], verbose=0)
 
-    all_preds = pd.Series([
-        [0.0] * len(CATS_CLASS_DICT) for i in range(len(midpointMjdTai))
-    ])
-    all_preds.loc[mask] = [list(i) for i in preds["dense_24"]]
+    preds.loc[mask] = [list(i) for i in valid_preds["dense_24"]]
 
-    return all_preds
+    return preds
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #642 

## What changes were proposed in this pull request?

Make CATS resilient against empty batches. Set verbosity to 0.

## How was this patch tested?

CI