### PR TITLE
[Rubin] Add pre-filtering for hostless

### DIFF
--- a/fink_science/rubin/hostless_detection/processor.py
+++ b/fink_science/rubin/hostless_detection/processor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 AstroLab Software
+# Copyright 2020-2026 AstroLab Software
 # Author: Rupesh Durgesh
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@ from line_profiler import profile
 import os
 
 import pandas as pd
+import numpy as np
 import pyspark.sql.functions as F
 from pyspark.sql.types import FloatType, MapType, StringType
 
@@ -38,11 +39,23 @@ CONFIGS = load_json(
 )
 CONFIGS.update(CONFIGS_BASE)
 
+ZP_NJY = 31.4
+
+BAD_VALUES = ["Unknown", "Fail", "Fail 504", None, np.nan]
+
 
 @F.pandas_udf(MapType(StringType(), FloatType()))
 @profile
 def run_potential_hostless(
-    cutoutScience: pd.Series, cutoutTemplate: pd.Series, ssObjectId: pd.Series
+    cutoutScience: pd.Series,
+    cutoutTemplate: pd.Series,
+    ssObjectId: pd.Series,
+    nDiaSources: pd.Series,
+    psfFlux: pd.Series,
+    midpointMjdTai: pd.Series,
+    firstDiaSourceMjdTaiFink: pd.Series,
+    simbad_otype: pd.Series,
+    gaiadr3_DR3Name: pd.Series,
 ) -> pd.Series:
     """Runs potential hostless candidate detection for Rubin without any filtering
 
@@ -52,6 +65,29 @@ def run_potential_hostless(
         science stamp images
     cutoutTemplate: pd.Series
         template stamp images
+    ssObjectId: pd.Series
+        SSO objectId. NaN if not existing.
+    nDiaSources: pd.Series
+        Number of previous detections
+    psfFlux: pd.Series
+        Flux in the difference image
+    midpointMjdTai: pd.Series
+        Emission date for the alert
+    firstDiaSourceMjdTaiFink: pd.Series
+        Date for the first time the alert was seen in Rubin
+    simbad_otype: pd.Series
+        SIMBAD type. NaN if not existing
+    gaiadr3_DR3Name: pd.Series
+        Name in Gaia DR3. NaN if not existing
+
+    Notes
+    -----
+    Cuts are applied before running the pipeline. Process if:
+    - Number of detections >= 3
+    - mag < 20
+    - first alert earlier than 30 days ago
+    - not in MPC, SIMBAD, Gaia DR3
+    Otherwise, the returned values for kstest are nulls.
 
     Returns
     -------
@@ -70,22 +106,68 @@ def run_potential_hostless(
     >>> df.count()
     25
 
-    # Add a new column
+    # No cuts
+    >>> df = df.withColumn('elephant_kstest_no_cuts',
+    ...     run_potential_hostless(
+    ...         df["cutoutScience"],
+    ...         df["cutoutTemplate"],
+    ...         F.lit(None),
+    ...         F.lit(3),
+    ...         F.lit(100000000),
+    ...         df["diaSource.midpointMjdTai"],
+    ...         df["diaSource.midpointMjdTai"],
+    ...         F.lit(None),
+    ...         F.lit(None),))
+    >>> df.filter(df.elephant_kstest_no_cuts.kstest_science.isNotNull()).count()
+    3
+
+    # SSO cuts
+    >>> df = df.withColumn('elephant_kstest_sso_cuts',
+    ...     run_potential_hostless(
+    ...         df["cutoutScience"],
+    ...         df["cutoutTemplate"],
+    ...         df["ssSource.ssObjectId"],
+    ...         F.lit(3),
+    ...         F.lit(100000000),
+    ...         df["diaSource.midpointMjdTai"],
+    ...         df["diaSource.midpointMjdTai"],
+    ...         F.lit(None),
+    ...         F.lit(None),))
+    >>> df.filter(df.elephant_kstest_sso_cuts.kstest_science.isNotNull()).count()
+    1
+
+    # All cuts
     >>> df = df.withColumn('elephant_kstest',
     ...     run_potential_hostless(
     ...         df["cutoutScience"],
     ...         df["cutoutTemplate"],
-    ...         df["ssSource.ssObjectId"]))
+    ...         df["ssSource.ssObjectId"],
+    ...         df["diaObject.nDiaSources"],
+    ...         df["diaSource.psfFlux"],
+    ...         df["diaSource.midpointMjdTai"],
+    ...         F.array_min("prvDiaSources.midpointMjdTai"),
+    ...         F.lit("star"),
+    ...         F.lit("DR3 toto"),))
     >>> df.filter(df.elephant_kstest.kstest_science.isNotNull()).count()
-    1
-    >>> df.filter(df.elephant_kstest.kstest_science.isNull()).count()
-    24
+    0
     """
+    f_min_point = nDiaSources >= 2  # N + 1
+    # FIXME: put the conversion formula in fink-utils
+    f_bright = (-2.5 * np.log10(psfFlux) + ZP_NJY) < 20
+    f_not_in_simbad = simbad_otype.apply(lambda val: val in BAD_VALUES or pd.isna(val))
+    f_not_in_gaia = gaiadr3_DR3Name.apply(lambda val: val in BAD_VALUES or pd.isna(val))
+    f_not_sso = ssObjectId.apply(lambda val: val in BAD_VALUES or pd.isna(val))
+    f_early = (midpointMjdTai - firstDiaSourceMjdTaiFink) < 30
+
+    good_candidate = (
+        f_min_point & f_bright & f_not_in_simbad & f_not_in_gaia & f_not_sso & f_early
+    )
+
     default_result = {"kstest_science": None, "kstest_template": None}
     kstest_results = []
     hostless_science_class = HostLessExtragalacticRubin(CONFIGS_BASE)
     for index in range(cutoutScience.shape[0]):
-        if (ssObjectId[index] is None) or pd.isna(ssObjectId[index]):
+        if good_candidate[index]:
             science_stamp = cutoutScience[index]
             template_stamp = cutoutTemplate[index]
             kstest_science, kstest_template = (


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #655 

## What changes were proposed in this pull request?

This PR adds a series of cuts before running the hostless pipeline. Statistics on 401831 alerts --> 114 pass the cuts (0.03%)

Throughput:

||  previous version| PR #647  | this version |
|--|-----------------------|--------------|-------------------|
|On-sky throughput (alert/s/core) | 10 | 50 | 3750 |

## How was this patch tested?

CI & cloud