### PR TITLE
Remove deprecated PandasUDFType from pandas UDF decorators

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -26,5 +26,5 @@ jobs:
         pip install ruff
     - name: utilities
       run: |
-        ruff check --preview --statistics . 
-        ruff format --preview --check .
+        ruff check --statistics .
+        ruff format --check .

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -38,7 +38,7 @@ target-version = "py39"
 
 [lint]
 # Rules can be found at https://docs.astral.sh/ruff/rules
-select = ["E4", "E7", "E9", "F", "E1", "E2", "W", "N", "D", "B", "C4", "PD", "PERF"]
+select = ["E4", "E7", "E9", "F", "E1", "W", "N", "D", "B", "C4", "PD", "PERF"]
 ignore = [
     "B023",
     "C408", "C420", "C901",

--- a/fink_science/data/catalogs/blazar_catalog_production.py
+++ b/fink_science/data/catalogs/blazar_catalog_production.py
@@ -485,9 +485,9 @@ def _get_class_ztf_identifier(
         return names[tags]
 
     # Step 2: candidate classes
-    tags = np.array([
-        bool(classes & candidate_source_classes) for classes in classifications
-    ])
+    tags = np.array(
+        [bool(classes & candidate_source_classes) for classes in classifications]
+    )
     if tags.any():
         logger.debug("Source candidate blazar in Fink classification.")
         return names[tags]

--- a/fink_science/rubin/ad_features/processor.py
+++ b/fink_science/rubin/ad_features/processor.py
@@ -134,12 +134,14 @@ def extract_features_ad_rubin_raw(
     extractor = create_extractor()
 
     try:
-        df = pd.DataFrame({
-            "time": midpointMjdTai,
-            "flux": psfFlux,
-            "err": psfFluxErr,
-            "band": band,
-        })
+        df = pd.DataFrame(
+            {
+                "time": midpointMjdTai,
+                "flux": psfFlux,
+                "err": psfFluxErr,
+                "band": band,
+            }
+        )
     except ValueError:
         logger.error(f"Array length mismatch for object {diaObjectId}")
         return {}
@@ -199,9 +201,11 @@ def extract_features_ad_rubin_raw(
 
 RETURN_TYPE = MapType(
     StringType(),  # passband
-    StructType([  # features name -> value
-        StructField(name, DoubleType(), True) for name in FEATURES_COLS
-    ]),
+    StructType(
+        [  # features name -> value
+            StructField(name, DoubleType(), True) for name in FEATURES_COLS
+        ]
+    ),
 )
 
 # Register the UDF

--- a/fink_science/rubin/cats/processor.py
+++ b/fink_science/rubin/cats/processor.py
@@ -111,9 +111,9 @@ def predict_nn(
 
     # check size of output
     """
-    preds = pd.Series([
-        [0.0] * len(CATS_CLASS_DICT) for i in range(len(midpointMjdTai))
-    ])
+    preds = pd.Series(
+        [[0.0] * len(CATS_CLASS_DICT) for i in range(len(midpointMjdTai))]
+    )
     # at least 2 points.
     mask = midpointMjdTai.apply(lambda x: len(x) > 1)
 

--- a/fink_science/rubin/hostless_detection/processor.py
+++ b/fink_science/rubin/hostless_detection/processor.py
@@ -285,10 +285,12 @@ def run_potential_hostless(
                         science_stamp, template_stamp
                     )
                 )
-                kstest_results.append({
-                    "kstest_science": kstest_science,
-                    "kstest_template": kstest_template,
-                })
+                kstest_results.append(
+                    {
+                        "kstest_science": kstest_science,
+                        "kstest_template": kstest_template,
+                    }
+                )
             else:
                 kstest_results.append(default_result)
         else:

--- a/fink_science/rubin/orphans/classifier.py
+++ b/fink_science/rubin/orphans/classifier.py
@@ -55,34 +55,42 @@ def get_features(ctimemjd, cabmags, cabmagserr, cfilts, valid):
     )
 
     # duration between the first detection and the peak
-    duration = np.array([
-        compute_duration_between_first_and_peak(t, m)
-        for t, m, v in zip(times.values, mags.values, valid.values)
-        if v
-    ])
+    duration = np.array(
+        [
+            compute_duration_between_first_and_peak(t, m)
+            for t, m, v in zip(times.values, mags.values, valid.values)
+            if v
+        ]
+    )
 
     # increase rate and decrease rates (average, in the 1/3 and the 3/3 parts of the light curve)
-    rates = np.array([
-        compute_rates(t, m, f)
-        for t, m, f, v in zip(times.values, mags.values, filts.values, valid.values)
-        if v
-    ])
+    rates = np.array(
+        [
+            compute_rates(t, m, f)
+            for t, m, f, v in zip(times.values, mags.values, filts.values, valid.values)
+            if v
+        ]
+    )
 
     # colours for the pairs (g, r) and (r, i)
-    colours = np.array([
-        compute_colours(t, m, f)
-        for t, m, f, v in zip(times.values, mags.values, filts.values, valid.values)
-        if v
-    ])
+    colours = np.array(
+        [
+            compute_colours(t, m, f)
+            for t, m, f, v in zip(times.values, mags.values, filts.values, valid.values)
+            if v
+        ]
+    )
 
     # parameters of the fit A, B, C, D and chi2
-    fit_parameters = np.array([
-        fit_light_curve(t, m, e, f)
-        for t, m, e, f, v in zip(
-            times.values, mags.values, err.values, filts.values, valid.values
-        )
-        if v
-    ])
+    fit_parameters = np.array(
+        [
+            fit_light_curve(t, m, e, f)
+            for t, m, e, f, v in zip(
+                times.values, mags.values, err.values, filts.values, valid.values
+            )
+            if v
+        ]
+    )
 
     # gather all the features in one DataFrame
     features = {

--- a/fink_science/rubin/random_forest_snia/processor.py
+++ b/fink_science/rubin/random_forest_snia/processor.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from pyspark.sql.functions import pandas_udf, PandasUDFType
+from pyspark.sql.functions import pandas_udf
 from pyspark.sql.types import DoubleType
 
 import pandas as pd
@@ -156,21 +156,18 @@ def extract_features_rainbow(
     return features[1:]
 
 
-@pandas_udf(DoubleType(), PandasUDFType.SCALAR)
+@pandas_udf(DoubleType())
 @profile
 def rfscore_rainbow_elasticc_nometa(
     midpointMjdTai: pd.Series,
     band: pd.Series,
     cpsfFlux: pd.Series,
     cpsfFluxErr: pd.Series,
-    maxduration=None,
-    model=None,
-    band_wave_aa=None,
-    with_baseline=None,
-    min_data_points=None,
-    low_bound=None,
 ) -> pd.Series:
     """Return the probability of an alert to be a SNe Ia using a Random Forest Classifier (rainbow fit) on ELaSTICC alert data.
+
+    Uses bundled model `data/models/elasticc_rainbow_earlyIa_nometa.pkl` and
+    default parameters (LSST band wavelengths, min_data_points=7, low_bound=-10).
 
     Parameters
     ----------
@@ -180,21 +177,6 @@ def rfscore_rainbow_elasticc_nometa(
         Filter IDs (vectors of str)
     cpsfFlux, cpsfFluxErr: Spark DataFrame Columns
         Magnitude from PSF-fit photometry, and 1-sigma error
-    maxduration: Spark DataFrame Column
-        Maximum duration in days to consider the object for classification (int).
-        Default is None, meaning no maximum duration applied.
-    model: Spark DataFrame Column, optional
-        Path to the trained model. Default is None, in which case the default
-        model `data/models/default-model.obj` is loaded.
-    band_wave_aa: Spark DataFrame Column
-        Dictionary with effective wavelength for each filter.
-        Default is for Elasticc.
-    with_baseline: Spark DataFrame Column
-        Baseline to be considered (bool). Default is False (baseline 0 in flux space).
-    min_data_points: Spark DataFrame Column
-       Minimum number of data points in all filters. Default is 7.
-    low_bound: Spark DataFrame Column
-        Lower bound of FLUXCAL to consider (float). Default is -10.
 
     Returns
     -------
@@ -231,43 +213,18 @@ def rfscore_rainbow_elasticc_nometa(
     >>> df.filter(df['pIa'] == -1.0).count()
     100
     """
-    if band_wave_aa is None:
-        band_wave_aa = pd.Series([
-            {
-                "u": 3671.0,
-                "g": 4827.0,
-                "r": 6223.0,
-                "i": 7546.0,
-                "z": 8691.0,
-                "y": 9712.0,
-            }
-        ])
-    if with_baseline is None:
-        with_baseline = pd.Series([False])
-    if min_data_points is None:
-        min_data_points = pd.Series([7])
-    if low_bound is None:
-        low_bound = pd.Series([-10])
+    _band_wave_aa = {
+        "u": 3671.0, "g": 4827.0, "r": 6223.0,
+        "i": 7546.0, "z": 8691.0, "y": 9712.0,
+    }
 
-    # dt is a column of floats
-    dt = midpointMjdTai.apply(lambda x: np.max(x) - np.min(x))
-
-    # Maximum days in the history
-    if maxduration is not None:
-        mask = dt <= maxduration.to_numpy()[0]
-    else:
-        mask = np.repeat(True, len(midpointMjdTai))
+    mask = np.repeat(True, len(midpointMjdTai))
 
     if len(midpointMjdTai[mask]) == 0:
         return pd.Series(np.zeros(len(midpointMjdTai), dtype=float))
 
-    # Load pre-trained model `clf`
-    if model is not None:
-        clf = load_scikit_model(model.to_numpy()[0])
-    else:
-        curdir = os.path.dirname(os.path.abspath(__file__))
-        model = curdir + "/data/models/elasticc_rainbow_earlyIa_nometa.pkl"
-        clf = pickle.load(open(model, "rb"))
+    curdir = os.path.dirname(os.path.abspath(__file__))
+    clf = pickle.load(open(curdir + "/data/models/elasticc_rainbow_earlyIa_nometa.pkl", "rb"))
 
     candid = pd.Series(range(len(midpointMjdTai)))
     ids = candid[mask]
@@ -284,10 +241,10 @@ def rfscore_rainbow_elasticc_nometa(
             band.to_numpy()[index][mjds_inds],
             cpsfFlux.to_numpy()[index][mjds_inds],
             cpsfFluxErr.to_numpy()[index][mjds_inds],
-            band_wave_aa=band_wave_aa.to_numpy()[0],
-            with_baseline=with_baseline.to_numpy()[0],
-            min_data_points=min_data_points.to_numpy()[0],
-            low_bound=low_bound.to_numpy()[0],
+            band_wave_aa=_band_wave_aa,
+            with_baseline=False,
+            min_data_points=7,
+            low_bound=-10,
         )
         if features[0] == 0.0:
             flag.append(False)

--- a/fink_science/rubin/random_forest_snia/processor.py
+++ b/fink_science/rubin/random_forest_snia/processor.py
@@ -24,7 +24,6 @@ import pickle
 
 from fink_science import __file__
 
-from fink_utils.data.utils import load_scikit_model
 
 from actsnfink.rainbow import fit_rainbow
 

--- a/fink_science/rubin/random_forest_snia/processor.py
+++ b/fink_science/rubin/random_forest_snia/processor.py
@@ -213,8 +213,12 @@ def rfscore_rainbow_elasticc_nometa(
     100
     """
     _band_wave_aa = {
-        "u": 3671.0, "g": 4827.0, "r": 6223.0,
-        "i": 7546.0, "z": 8691.0, "y": 9712.0,
+        "u": 3671.0,
+        "g": 4827.0,
+        "r": 6223.0,
+        "i": 7546.0,
+        "z": 8691.0,
+        "y": 9712.0,
     }
 
     mask = np.repeat(True, len(midpointMjdTai))
@@ -223,7 +227,9 @@ def rfscore_rainbow_elasticc_nometa(
         return pd.Series(np.zeros(len(midpointMjdTai), dtype=float))
 
     curdir = os.path.dirname(os.path.abspath(__file__))
-    model_path = os.path.join(curdir, "data", "models", "elasticc_rainbow_earlyIa_nometa.pkl")
+    model_path = os.path.join(
+        curdir, "data", "models", "elasticc_rainbow_earlyIa_nometa.pkl"
+    )
     with open(model_path, "rb") as f:
         clf = pickle.load(f)
 

--- a/fink_science/rubin/random_forest_snia/processor.py
+++ b/fink_science/rubin/random_forest_snia/processor.py
@@ -224,7 +224,9 @@ def rfscore_rainbow_elasticc_nometa(
         return pd.Series(np.zeros(len(midpointMjdTai), dtype=float))
 
     curdir = os.path.dirname(os.path.abspath(__file__))
-    clf = pickle.load(open(curdir + "/data/models/elasticc_rainbow_earlyIa_nometa.pkl", "rb"))
+    model_path = os.path.join(curdir, "data", "models", "elasticc_rainbow_earlyIa_nometa.pkl")
+    with open(model_path, "rb") as f:
+        clf = pickle.load(f)
 
     candid = pd.Series(range(len(midpointMjdTai)))
     ids = candid[mask]

--- a/fink_science/rubin/slsn/feature_extraction.py
+++ b/fink_science/rubin/slsn/feature_extraction.py
@@ -117,28 +117,30 @@ def parametrise(transformed, metadata, target_col=""):
     warnings.filterwarnings("ignore", category=rainbow_warnings.ExperimentalWarning)
     rainbow_features = transformed.apply(apply_rainbow, axis=1)
 
-    for idx, name in enumerate([
-        "reference_time",
-        "rise_time",
-        "amplitude",
-        "Tmin",
-        "Tmax",
-        "t_color",
-        "fit_error",
-    ]):
+    for idx, name in enumerate(
+        [
+            "reference_time",
+            "rise_time",
+            "amplitude",
+            "Tmin",
+            "Tmax",
+            "t_color",
+            "fit_error",
+        ]
+    ):
         df_parameters[name] = [i[idx] for i in rainbow_features]
 
     for band in k.PASSBANDS:
         masks = transformed["cband"].apply(lambda x: x == band)
 
-        single_band_flux = pd.Series([
-            k[masks.iloc[idx2]] for idx2, k in enumerate(transformed["cpsfFlux"])
-        ])
+        single_band_flux = pd.Series(
+            [k[masks.iloc[idx2]] for idx2, k in enumerate(transformed["cpsfFlux"])]
+        )
         std = single_band_flux.apply(base.compute_std)
 
-        single_band_snr = pd.Series([
-            k[masks.iloc[idx2]] for idx2, k in enumerate(transformed["snr"])
-        ])
+        single_band_snr = pd.Series(
+            [k[masks.iloc[idx2]] for idx2, k in enumerate(transformed["snr"])]
+        )
         mean_snr = single_band_snr.apply(base.compute_mean)
 
         df_parameters[f"std_{band}"] = list(std)

--- a/fink_science/rubin/slsn/processor.py
+++ b/fink_science/rubin/slsn/processor.py
@@ -76,15 +76,17 @@ def slsn_rubin(diaObjectId, cmidpointMjdTai, cpsfFlux, cpsfFluxErr, cband, ra, d
     >>> df.filter(df['preds'] == 0).count()
     50
     """
-    data = pd.DataFrame({
-        "diaObjectId": diaObjectId,
-        "cmidpointMjdTai": cmidpointMjdTai,
-        "cpsfFlux": cpsfFlux,
-        "cpsfFluxErr": cpsfFluxErr,
-        "cband": cband,
-        "ra": ra,
-        "dec": dec,
-    })
+    data = pd.DataFrame(
+        {
+            "diaObjectId": diaObjectId,
+            "cmidpointMjdTai": cmidpointMjdTai,
+            "cpsfFlux": cpsfFlux,
+            "cpsfFluxErr": cpsfFluxErr,
+            "cband": cband,
+            "ra": ra,
+            "dec": dec,
+        }
+    )
 
     proba = slsn_classifier(data, False)
     return pd.Series(proba)

--- a/fink_science/rubin/snn/processor.py
+++ b/fink_science/rubin/snn/processor.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from line_profiler import profile
 
-from pyspark.sql.functions import pandas_udf, PandasUDFType
+from pyspark.sql.functions import pandas_udf
 from pyspark.sql.types import FloatType, ArrayType
 
 from supernnova.validation.validate_onthefly import classify_lcs
@@ -32,7 +32,7 @@ from fink_utils.data.utils import format_data_as_snana
 from fink_science.tester import spark_unit_tests
 
 
-@pandas_udf(FloatType(), PandasUDFType.SCALAR)
+@pandas_udf(FloatType())
 @profile
 def snn_ia_elasticc(
     diaSourceId: pd.Series,
@@ -41,7 +41,6 @@ def snn_ia_elasticc(
     psfFlux: pd.Series,
     psfFluxErr: pd.Series,
     model_name: pd.Series,
-    model_ext=None,
 ) -> pd.Series:
     """Compute probabilities of alerts to be SN Ia using SuperNNova
 
@@ -60,8 +59,6 @@ def snn_ia_elasticc(
     model_name: Spark DataFrame Column
         SuperNNova pre-trained model. Currently available:
             * elasticc
-    model_ext: Spark DataFrame Column, optional
-        Path to the trained model (overwrite `model_name`). Default is None
 
     Returns
     -------
@@ -129,15 +126,10 @@ def snn_ia_elasticc(
         transform_to_flux=False,
     )
 
-    if model_ext is not None:
-        # take the first element of the Series
-        model = model_ext.to_numpy()[0]
-    else:
-        # Load pre-trained model
-        curdir = os.path.dirname(os.path.abspath(__file__))
-        model = curdir + "/data/models/snn_models/{}/model.pt".format(
-            model_name.to_numpy()[0]
-        )
+    curdir = os.path.dirname(os.path.abspath(__file__))
+    model = curdir + "/data/models/snn_models/{}/model.pt".format(
+        model_name.to_numpy()[0]
+    )
 
     # Compute predictions
     if len(pdf) == 0:
@@ -165,7 +157,7 @@ def extract_max_prob(arr):
     return {"class": index, "prob": array[index]}
 
 
-@pandas_udf(ArrayType(FloatType()), PandasUDFType.SCALAR)
+@pandas_udf(ArrayType(FloatType()))
 @profile
 def snn_broad_elasticc(
     diaSourceId: pd.Series,
@@ -174,7 +166,6 @@ def snn_broad_elasticc(
     psfFlux: pd.Series,
     psfFluxErr: pd.Series,
     model_name: pd.Series,
-    model_ext=None,
 ) -> pd.Series:
     """Compute main class and associated probability for each alert
 
@@ -193,8 +184,6 @@ def snn_broad_elasticc(
     model_name: Spark DataFrame Column
         SuperNNova pre-trained model. Currently available:
             * elasticc
-    model_ext: Spark DataFrame Column, optional
-        Path to the trained model (overwrite `model_name`). Default is None
 
     Returns
     -------
@@ -224,15 +213,10 @@ def snn_broad_elasticc(
         transform_to_flux=False,
     )
 
-    if model_ext is not None:
-        # take the first element of the Series
-        model = model_ext.to_numpy()[0]
-    else:
-        # Load pre-trained model
-        curdir = os.path.dirname(os.path.abspath(__file__))
-        model = curdir + "/data/models/snn_models/{}/model.pt".format(
-            model_name.to_numpy()[0]
-        )
+    curdir = os.path.dirname(os.path.abspath(__file__))
+    model = curdir + "/data/models/snn_models/{}/model.pt".format(
+        model_name.to_numpy()[0]
+    )
 
     # Compute predictions
     if len(pdf) == 0:

--- a/fink_science/rubin/xmatch/processor.py
+++ b/fink_science/rubin/xmatch/processor.py
@@ -417,9 +417,9 @@ def xmatch_tns(df, distmaxarcsec=1.5, tns_raw_output=""):
     spark = SparkSession.builder.getOrCreate()
     pdf_tns_b = spark.sparkContext.broadcast(pdf_tns)
 
-    tns_schema = StructType([
-        StructField(k, v, True) for k, v in TNS_SPARK_SCHEMA.items()
-    ])
+    tns_schema = StructType(
+        [StructField(k, v, True) for k, v in TNS_SPARK_SCHEMA.items()]
+    )
 
     @pandas_udf(tns_schema)
     def crossmatch_with_tns(
@@ -441,11 +441,13 @@ def xmatch_tns(df, distmaxarcsec=1.5, tns_raw_output=""):
         to_return: pd.Series of dict
             TNS name and type for the alert. null if no match.
         """
-        pdf_lsst = pd.DataFrame({
-            "diaSourceId": range(len(ra)),
-            "ra": ra.to_numpy(),
-            "dec": dec.to_numpy(),
-        })
+        pdf_lsst = pd.DataFrame(
+            {
+                "diaSourceId": range(len(ra)),
+                "ra": ra.to_numpy(),
+                "dec": dec.to_numpy(),
+            }
+        )
 
         ra2, dec2, payload = extract_tns(pdf_tns_b.value)
 
@@ -480,9 +482,9 @@ def xmatch_tns(df, distmaxarcsec=1.5, tns_raw_output=""):
 
         default = [None] * len(TNS_SPARK_SCHEMA)
         pdf_merge["return"] = pd.Series([default for i in range(len(pdf_merge))])
-        pdf_merge.loc[mask, "return"] = pd.Series([
-            [None if pd.isna(x) else x for x in payload[i].tolist()] for i in idx2
-        ]).to_numpy()
+        pdf_merge.loc[mask, "return"] = pd.Series(
+            [[None if pd.isna(x) else x for x in payload[i].tolist()] for i in idx2]
+        ).to_numpy()
 
         out = pd.DataFrame.from_dict(
             dict(zip(pdf_merge["return"].index, pdf_merge["return"].values)),
@@ -643,11 +645,13 @@ def crossmatch_other_catalog(
     # set separation length
     radius_arcsec = float(radius_arcsec.to_numpy()[0])
 
-    pdf = pd.DataFrame({
-        "ra": ra.to_numpy(),
-        "dec": dec.to_numpy(),
-        "diaSourceId": range(len(ra)),
-    })
+    pdf = pd.DataFrame(
+        {
+            "ra": ra.to_numpy(),
+            "dec": dec.to_numpy(),
+            "diaSourceId": range(len(ra)),
+        }
+    )
 
     curdir = os.path.dirname(os.path.abspath(__file__))
     if catalog_name.to_numpy()[0] == "gcvs":
@@ -770,11 +774,13 @@ def crossmatch_mangrove(
     # set separation length
     radius_arcsec = float(radius_arcsec.to_numpy()[0])
 
-    pdf = pd.DataFrame({
-        "ra": ra.to_numpy(),
-        "dec": dec.to_numpy(),
-        "diaSourceId": range(len(ra)),
-    })
+    pdf = pd.DataFrame(
+        {
+            "ra": ra.to_numpy(),
+            "dec": dec.to_numpy(),
+            "diaSourceId": range(len(ra)),
+        }
+    )
 
     curdir = os.path.dirname(os.path.abspath(__file__))
     catalog = curdir + "/data/catalogs/mangrove_filtered.parquet"

--- a/fink_science/rubin/xmatch/utils.py
+++ b/fink_science/rubin/xmatch/utils.py
@@ -72,10 +72,12 @@ def cross_match_astropy(pdf, catalog_lsst, catalog_other, radius_arcsec=None):
     catalog_matches = np.unique(pdf["diaSourceId"].to_numpy()[idx[sep_constraint]])
 
     # identify position of matches in the input dataframe
-    pdf_matches = pd.DataFrame({
-        "diaSourceId": np.array(catalog_matches, dtype=np.int64),
-        "match": True,
-    })
+    pdf_matches = pd.DataFrame(
+        {
+            "diaSourceId": np.array(catalog_matches, dtype=np.int64),
+            "match": True,
+        }
+    )
     pdf_merge = pdf.merge(pdf_matches, how="left", on="diaSourceId")
 
     mask = pdf_merge["match"].apply(lambda x: x is True)

--- a/fink_science/tester.py
+++ b/fink_science/tester.py
@@ -87,25 +87,28 @@ def spark_unit_tests(global_args: dict = None, verbose: bool = False):
     confdic = {"spark.python.daemon.module": "coverage_daemon"}
 
     if spark.version.startswith("2"):
-        confdic.update({
-            "spark.jars.packages": "org.apache.spark:spark-avro_2.11:{}".format(
-                spark.version
-            )
-        })
+        confdic.update(
+            {
+                "spark.jars.packages": "org.apache.spark:spark-avro_2.11:{}".format(
+                    spark.version
+                )
+            }
+        )
     elif spark.version.startswith("3"):
         py4j_mod = "org.slf4j:slf4j-log4j12:1.7.36,org.slf4j:slf4j-simple:1.7.36"
-        confdic.update({
-            "spark.jars.packages": "org.apache.spark:spark-avro_2.12:{},{}".format(
-                spark.version, py4j_mod
-            )
-        })
+        confdic.update(
+            {
+                "spark.jars.packages": "org.apache.spark:spark-avro_2.12:{},{}".format(
+                    spark.version, py4j_mod
+                )
+            }
+        )
     conf.setMaster("local[2]")
     conf.setAppName("fink_science_test")
     for k, v in confdic.items():
         conf.set(key=k, value=v)
     spark = (
-        SparkSession.builder
-        .appName("fink_science_test")
+        SparkSession.builder.appName("fink_science_test")
         .config(conf=conf)
         .getOrCreate()
     )

--- a/fink_science/ztf/ad_features/processor.py
+++ b/fink_science/ztf/ad_features/processor.py
@@ -228,9 +228,11 @@ extract_features_ad = udf(
     f=extract_features_ad_raw,
     returnType=MapType(
         IntegerType(),  # passband_id
-        StructType([  # features name -> value
-            StructField(name, DoubleType(), True) for name in FEATURES_COLS
-        ]),
+        StructType(
+            [  # features name -> value
+                StructField(name, DoubleType(), True) for name in FEATURES_COLS
+            ]
+        ),
     ),
 )
 

--- a/fink_science/ztf/ad_features/test.py
+++ b/fink_science/ztf/ad_features/test.py
@@ -37,10 +37,12 @@ features = []
 for name in names:
     with open(f"{path}/tests/{name}.features") as features_file:
         lines = features_file.readlines()[::2]
-        features.append({
-            split[0]: float(split[1][:-1])
-            for split in map(lambda ln: ln.split(": "), lines)  # noqa: C417
-        })
+        features.append(
+            {
+                split[0]: float(split[1][:-1])
+                for split in map(lambda ln: ln.split(": "), lines)  # noqa: C417
+            }
+        )
 
 result_features = []
 for index, dataset in enumerate(test_datasets):
@@ -52,9 +54,9 @@ for index, dataset in enumerate(test_datasets):
         index,
         np.ones(len(dataset.mag)) * 10.0,  # extra-galactic
     )
-    result_features.append({
-        lc_columns[i]: result[1][lc_columns[i]] for i in range(len(lc_columns))
-    })
+    result_features.append(
+        {lc_columns[i]: result[1][lc_columns[i]] for i in range(len(lc_columns))}
+    )
 
 errors = defaultdict(dict)
 # Tolerated deviance is 5%

--- a/fink_science/ztf/anomaly_detection/processor.py
+++ b/fink_science/ztf/anomaly_detection/processor.py
@@ -125,8 +125,7 @@ class TwoBandModel:
         masked_scores_g = ma.array(scores_g, mask=mask_g.to_numpy())
         masked_scores_r = ma.array(scores_r, mask=mask_r.to_numpy())
         final_scores = (
-            ma
-            .column_stack([masked_scores_g, masked_scores_r])
+            ma.column_stack([masked_scores_g, masked_scores_r])
             .min(axis=1)
             .filled(np.nan)
         )

--- a/fink_science/ztf/blazar_extreme_state/processor.py
+++ b/fink_science/ztf/blazar_extreme_state/processor.py
@@ -201,14 +201,16 @@ def extreme_state(
     CTAO_blazar = pd.read_parquet(os.path.join(CTAO_PATH, CTAO_filename))
 
     # Transform alert packet to pandas DataFrame
-    pdf = pd.DataFrame({
-        "candid": candid,
-        "objectId": objectId,
-        "cstd_flux": cstd_flux,
-        "cjd": cjd,
-        "cra": cra,
-        "cdec": cdec,
-    })
+    pdf = pd.DataFrame(
+        {
+            "candid": candid,
+            "objectId": objectId,
+            "cstd_flux": cstd_flux,
+            "cjd": cjd,
+            "cra": cra,
+            "cdec": cdec,
+        }
+    )
     out = []
 
     # Loop over all candidate ids
@@ -221,14 +223,16 @@ def extreme_state(
             continue
 
         # Else:
-        sub = pd.DataFrame({
-            "candid": tmp["candid"].to_numpy()[0],
-            "objectId": tmp["objectId"].to_numpy()[0],
-            "cstd_flux": tmp["cstd_flux"].to_numpy()[0],
-            "cjd": tmp["cjd"].to_numpy()[0],
-            "cra": tmp["cra"].to_numpy()[0],
-            "cdec": tmp["cdec"].to_numpy()[0],
-        })
+        sub = pd.DataFrame(
+            {
+                "candid": tmp["candid"].to_numpy()[0],
+                "objectId": tmp["objectId"].to_numpy()[0],
+                "cstd_flux": tmp["cstd_flux"].to_numpy()[0],
+                "cjd": tmp["cjd"].to_numpy()[0],
+                "cra": tmp["cra"].to_numpy()[0],
+                "cdec": tmp["cdec"].to_numpy()[0],
+            }
+        )
 
         # Low state verification
         low_state_dic = dict(

--- a/fink_science/ztf/blazar_extreme_state/utils.py
+++ b/fink_science/ztf/blazar_extreme_state/utils.py
@@ -190,10 +190,12 @@ def extreme_state_(
     _LOG.info(f"Extreme state determination of {name}.")
 
     if not CTAO_blazar.loc[CTAO_blazar["ZTF_name"] == name].empty:
-        return np.array([
-            _robustness_criterion(pdf, CTAO_blazar, state_key, integration_period),
-            _instantness_criterion(pdf, CTAO_blazar, state_key),
-        ])
+        return np.array(
+            [
+                _robustness_criterion(pdf, CTAO_blazar, state_key, integration_period),
+                _instantness_criterion(pdf, CTAO_blazar, state_key),
+            ]
+        )
 
     else:
         return np.full(2, -1)

--- a/fink_science/ztf/blazar_low_state/processor.py
+++ b/fink_science/ztf/blazar_low_state/processor.py
@@ -133,24 +133,28 @@ def quiescent_state(
     CTAO_filename = "CTAO_blazars_ztf_dr{}.parquet".format(CATALOG_TAG)
     CTAO_blazar = pd.read_parquet(os.path.join(CTAO_PATH, CTAO_filename))
 
-    pdf = pd.DataFrame({
-        "candid": candid,
-        "objectId": objectId,
-        "cstd_flux": cstd_flux,
-        "cjd": cjd,
-    })
+    pdf = pd.DataFrame(
+        {
+            "candid": candid,
+            "objectId": objectId,
+            "cstd_flux": cstd_flux,
+            "cjd": cjd,
+        }
+    )
     out = []
     for candid_ in pdf["candid"]:
         tmp = pdf[pdf["candid"] == candid_]
         if len(tmp["cstd_flux"].to_numpy()[0]) == 0:
             out.append({k: -1 for k in BLAZAR_COLS})
             continue
-        sub = pd.DataFrame({
-            "candid": tmp["candid"].to_numpy()[0],
-            "objectId": tmp["objectId"].to_numpy()[0],
-            "cstd_flux": tmp["cstd_flux"].to_numpy()[0],
-            "cjd": tmp["cjd"].to_numpy()[0],
-        })
+        sub = pd.DataFrame(
+            {
+                "candid": tmp["candid"].to_numpy()[0],
+                "objectId": tmp["objectId"].to_numpy()[0],
+                "cstd_flux": tmp["cstd_flux"].to_numpy()[0],
+                "cjd": tmp["cjd"].to_numpy()[0],
+            }
+        )
         dic = {k: v for k, v in zip(BLAZAR_COLS, quiescent_state_(sub, CTAO_blazar))}  # noqa: C416
         out.append(dic)
 

--- a/fink_science/ztf/blazar_low_state/utils.py
+++ b/fink_science/ztf/blazar_low_state/utils.py
@@ -140,11 +140,13 @@ def quiescent_state_(pdf: pd.DataFrame, CTAO_blazar: pd.DataFrame) -> np.ndarray
     c0 = not CTAO_blazar.loc[CTAO_blazar["ZTF Name"] == name].empty
     c1 = not pdf[:-1].empty
     if c0 and c1:
-        return np.array([
-            robustness_criterion(pdf[:-1], CTAO_blazar),
-            robustness_criterion(pdf, CTAO_blazar),
-            instantness_criterion(pdf, CTAO_blazar),
-        ])
+        return np.array(
+            [
+                robustness_criterion(pdf[:-1], CTAO_blazar),
+                robustness_criterion(pdf, CTAO_blazar),
+                instantness_criterion(pdf, CTAO_blazar),
+            ]
+        )
 
     else:
         return np.full(3, np.nan)

--- a/fink_science/ztf/fast_transient_rate/processor.py
+++ b/fink_science/ztf/fast_transient_rate/processor.py
@@ -285,23 +285,25 @@ def fast_transient_rate(df: pd.DataFrame, N: int, seed: int = None) -> pd.DataFr
     upper_rate[idx_last_upper] = np.percentile(sample_rate_upper, 95.0, axis=1)
 
     return pd.DataFrame(
-        np.array([
-            tmp_last[:, -1],
-            jdstarthist_dt,
-            res_rate,
-            res_sigmarate,
-            lower_rate,
-            upper_rate,
-            dt,
-            (~mask_finite_mag) & mask_finite_upper,
-        ]).T,
+        np.array(
+            [
+                tmp_last[:, -1],
+                jdstarthist_dt,
+                res_rate,
+                res_sigmarate,
+                lower_rate,
+                upper_rate,
+                dt,
+                (~mask_finite_mag) & mask_finite_upper,
+            ]
+        ).T,
         columns=list(rate_module_output_schema.keys()),
     )
 
 
-ft_schema = StructType([
-    StructField(k, v, True) for k, v in rate_module_output_schema.items()
-])
+ft_schema = StructType(
+    [StructField(k, v, True) for k, v in rate_module_output_schema.items()]
+)
 
 
 @pandas_udf(ft_schema)
@@ -354,18 +356,20 @@ def magnitude_rate(
     see fast_transient_rate documentation
 
     """
-    pdf = pd.DataFrame({
-        "magpsf": magpsf,
-        "sigmapsf": sigmapsf,
-        "jd": jd,
-        "jdstarthist": jdstarthist,
-        "fid": fid,
-        "cmagpsf": cmagpsf,
-        "csigmapsf": csigmapsf,
-        "cdiffmaglim": cdiffmaglim,
-        "cjd": cjd,
-        "cfid": cfid,
-    })
+    pdf = pd.DataFrame(
+        {
+            "magpsf": magpsf,
+            "sigmapsf": sigmapsf,
+            "jd": jd,
+            "jdstarthist": jdstarthist,
+            "fid": fid,
+            "cmagpsf": cmagpsf,
+            "csigmapsf": csigmapsf,
+            "cdiffmaglim": cdiffmaglim,
+            "cjd": cjd,
+            "cfid": cfid,
+        }
+    )
 
     return fast_transient_rate(pdf, N.to_numpy()[0], seed.to_numpy()[0])
 

--- a/fink_science/ztf/hostless_detection/processor.py
+++ b/fink_science/ztf/hostless_detection/processor.py
@@ -229,17 +229,21 @@ def run_potential_hostless(
                         science_stamp, template_stamp
                     )
                 )
-                kstest_results.append([
-                    kstest_science,
-                    kstest_template,
-                    is_processed_true,
-                ])
+                kstest_results.append(
+                    [
+                        kstest_science,
+                        kstest_template,
+                        is_processed_true,
+                    ]
+                )
             else:
-                kstest_results.append([
-                    default_result,
-                    default_result,
-                    is_processed_false,
-                ])
+                kstest_results.append(
+                    [
+                        default_result,
+                        default_result,
+                        is_processed_false,
+                    ]
+                )
         else:
             kstest_results.append([default_result, default_result, is_processed_false])
     return pd.Series(kstest_results)

--- a/fink_science/ztf/kilonova/processor.py
+++ b/fink_science/ztf/kilonova/processor.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from line_profiler import profile
 
-from pyspark.sql.functions import pandas_udf, PandasUDFType
+from pyspark.sql.functions import pandas_udf
 from pyspark.sql.types import DoubleType, StringType
 
 import pandas as pd
@@ -34,7 +34,7 @@ from kndetect.features import extract_features_all_lightcurves, get_feature_name
 from fink_science.tester import spark_unit_tests
 
 
-@pandas_udf(DoubleType(), PandasUDFType.SCALAR)
+@pandas_udf(DoubleType())
 @profile
 def knscore(
     jd: pd.Series,
@@ -44,11 +44,10 @@ def knscore(
     jdstarthist: pd.Series,
     cdsxmatch: pd.Series,
     ndethist: pd.Series,
-    model_name=None,
 ) -> pd.Series:
     """Return the probability of an alert to be a Kilonova using a Random Forest Classifier.
 
-    You need to run the SIMBAD crossmatch before.
+    You need to run the SIMBAD crossmatch before. Uses model "partial.pkl" from kndetect.
 
     Parameters
     ----------
@@ -64,10 +63,6 @@ def knscore(
         Column containing the number of detection by ZTF at 3 sigma (int)
     jdstarthist: Spark DataFrame Column
         Column containing first time variability has been seen
-    model_name: str
-        Nome of the model to be fetched from the kndetect package.
-        supported options: "complete.pkl", "partial.pkl"
-        deault is "partial.pkl" (model trained for complete light curves)
 
     Returns
     -------
@@ -110,15 +105,6 @@ def knscore(
     |           0.0|0.6333333333333333|
     +--------------+------------------+
     <BLANKLINE>
-
-    # Perform the fit + classification (another model)
-    >>> args = [F.col(i) for i in what_prefix]
-    >>> args += [F.col('candidate.jdstarthist'), F.col('cdsxmatch'), F.col('candidate.ndethist')]
-    >>> args += [F.lit('partial.pkl')]
-    >>> df = df.withColumn('pKNe', knscore(*args))
-
-    >>> df.filter(df['pKNe'] > 0.5).count()
-    1
 
     # check robustness wrt i-band
     >>> df = spark.read.load(ztf_alert_with_i_band)
@@ -174,11 +160,7 @@ def knscore(
         "FLT": fid[mask].explode().replace({1: "g", 2: "r"}),
     })
 
-    # Load pre-trained model
-    if model_name is None:
-        model = load_classifier("partial.pkl")
-    else:
-        model = load_classifier(model_name.to_numpy()[0])
+    model = load_classifier("partial.pkl")
 
     # Load pcs
     pcs = load_pcs()
@@ -311,9 +293,6 @@ if __name__ == "__main__":
 
     globs = globals()
     path = os.path.dirname(__file__)
-
-    model_name = "partial.pkl"
-    globs["model_name"] = model_name
 
     ztf_alert_sample = "file://{}/data/alerts/datatest".format(path)
     globs["ztf_alert_sample"] = ztf_alert_sample

--- a/fink_science/ztf/kilonova/processor.py
+++ b/fink_science/ztf/kilonova/processor.py
@@ -152,13 +152,15 @@ def knscore(
     flux, error = np.transpose(data)
 
     # make a Pandas DataFrame with exploded series
-    pdf = pd.DataFrame.from_dict({
-        "SNID": df_tmp["SNID"],
-        "MJD": df_tmp["jd"],
-        "FLUXCAL": flux,
-        "FLUXCALERR": error,
-        "FLT": fid[mask].explode().replace({1: "g", 2: "r"}),
-    })
+    pdf = pd.DataFrame.from_dict(
+        {
+            "SNID": df_tmp["SNID"],
+            "MJD": df_tmp["jd"],
+            "FLUXCAL": flux,
+            "FLUXCALERR": error,
+            "FLT": fid[mask].explode().replace({1: "g", 2: "r"}),
+        }
+    )
 
     model = load_classifier("partial.pkl")
 
@@ -257,13 +259,15 @@ def extract_features_knscore(
     flux, error = np.transpose(data)
 
     # make a Pandas DataFrame with exploded series
-    pdf = pd.DataFrame.from_dict({
-        "SNID": df_tmp["SNID"],
-        "MJD": df_tmp["jd"],
-        "FLUXCAL": flux,
-        "FLUXCALERR": error,
-        "FLT": fid[mask].explode().replace({1: "g", 2: "r"}),
-    })
+    pdf = pd.DataFrame.from_dict(
+        {
+            "SNID": df_tmp["SNID"],
+            "MJD": df_tmp["jd"],
+            "FLUXCAL": flux,
+            "FLUXCALERR": error,
+            "FLT": fid[mask].explode().replace({1: "g", 2: "r"}),
+        }
+    )
 
     # Load pcs
     pcs = load_pcs()

--- a/fink_science/ztf/microlensing/processor.py
+++ b/fink_science/ztf/microlensing/processor.py
@@ -159,16 +159,18 @@ def mulens(
                 continue
 
             # Compute DC mag
-            mag, err = np.array([
-                dc_mag(i[0], i[1], i[2], i[3], i[4])
-                for i in zip(
-                    np.array(magpsf.to_numpy()[index])[m],
-                    np.array(sigmapsf.to_numpy()[index])[m],
-                    np.array(magnr.to_numpy()[index])[m],
-                    np.array(sigmagnr.to_numpy()[index])[m],
-                    np.array(isdiffpos.to_numpy()[index])[m],
-                )
-            ]).T
+            mag, err = np.array(
+                [
+                    dc_mag(i[0], i[1], i[2], i[3], i[4])
+                    for i in zip(
+                        np.array(magpsf.to_numpy()[index])[m],
+                        np.array(sigmapsf.to_numpy()[index])[m],
+                        np.array(magnr.to_numpy()[index])[m],
+                        np.array(sigmagnr.to_numpy()[index])[m],
+                        np.array(isdiffpos.to_numpy()[index])[m],
+                    )
+                ]
+            ).T
 
             # Run the classifier
             output = microlensing_classifier.predict(mag, err, rf, pca)
@@ -272,16 +274,18 @@ def extract_features_mulens(
                 continue
 
             # Compute DC mag
-            mag, err = np.array([
-                dc_mag(i[0], i[1], i[2], i[3], i[4])
-                for i in zip(
-                    np.array(magpsf.to_numpy()[index])[m],
-                    np.array(sigmapsf.to_numpy()[index])[m],
-                    np.array(magnr.to_numpy()[index])[m],
-                    np.array(sigmagnr.to_numpy()[index])[m],
-                    np.array(isdiffpos.to_numpy()[index])[m],
-                )
-            ]).T
+            mag, err = np.array(
+                [
+                    dc_mag(i[0], i[1], i[2], i[3], i[4])
+                    for i in zip(
+                        np.array(magpsf.to_numpy()[index])[m],
+                        np.array(sigmapsf.to_numpy()[index])[m],
+                        np.array(magnr.to_numpy()[index])[m],
+                        np.array(sigmagnr.to_numpy()[index])[m],
+                        np.array(isdiffpos.to_numpy()[index])[m],
+                    )
+                ]
+            ).T
 
             # Extract features
             output = _extract(mag, err)

--- a/fink_science/ztf/random_forest_snia/processor.py
+++ b/fink_science/ztf/random_forest_snia/processor.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from pyspark.sql.functions import pandas_udf, PandasUDFType
+from pyspark.sql.functions import pandas_udf
 from pyspark.sql.types import DoubleType, StringType
 
 import pandas as pd
@@ -74,7 +74,7 @@ def apply_selection_cuts_ztf(
     return mask
 
 
-@pandas_udf(DoubleType(), PandasUDFType.SCALAR)
+@pandas_udf(DoubleType())
 @profile
 def rfscore_sigmoid_full(
     jd: pd.Series,
@@ -83,14 +83,12 @@ def rfscore_sigmoid_full(
     sigmapsf: pd.Series,
     cdsxmatch: pd.Series,
     ndethist: pd.Series,
-    min_rising_points=None,
-    min_data_points=None,
-    rising_criteria=None,
-    model=None,
 ) -> pd.Series:
     """Return the probability of an alert to be a SNe Ia using a Random Forest Classifier (sigmoid fit).
 
-    You need to run the SIMBAD crossmatch before.
+    You need to run the SIMBAD crossmatch before. Uses default parameters
+    (min_rising_points=2, min_data_points=4, rising_criteria="ewma") and the
+    bundled model `data/models/default-model_sigmoid.obj`.
 
     Parameters
     ----------
@@ -104,13 +102,6 @@ def rfscore_sigmoid_full(
         Type of object found in Simbad (string)
     ndethist: Spark DataFrame Column
         Column containing the number of detection by ZTF at 3 sigma (int)
-    min_rising_points, min_data_points: int
-        Parameters from fink_sn_activelearning.git
-    rising_criteria: str
-        How to compute derivatives: ewma (default), or diff.
-    model: Spark DataFrame Column, optional
-        Path to the trained model. Default is None, in which case the default
-        model `data/models/default-model.obj` is loaded.
 
     Returns
     -------
@@ -159,28 +150,6 @@ def rfscore_sigmoid_full(
     +----------------+-----+
     <BLANKLINE>
 
-    # We can also specify fink_sn_activelearning parameters
-    >>> args = [F.col(i) for i in what_prefix]
-    >>> args += [F.col('cdsxmatch'), F.col('candidate.ndethist')]
-    >>> args += [F.lit(2), F.lit(4), F.lit('ewma')]
-    >>> df = df.withColumn('pIa', rfscore_sigmoid_full(*args))
-
-    >>> df.filter(df['pIa'] > 0.5).count()
-    6
-
-    # We can also specify a different model
-    >>> args = [F.col(i) for i in what_prefix]
-    >>> args += [F.col('cdsxmatch'), F.col('candidate.ndethist')]
-    >>> args += [F.lit(1), F.lit(3), F.lit('diff')]
-    >>> args += [F.lit(model_path_al_loop)]
-    >>> df = df.withColumn('pIaAL', rfscore_sigmoid_full(*args))
-
-    >>> df.filter(df['pIaAL'] > 0.5).count()
-    5
-
-    >>> df.agg({"pIaAL": "max"}).collect()[0][0] < 1.0
-    True
-
     # check robustness wrt i-band
     >>> df = spark.read.load(ztf_alert_with_i_band)
 
@@ -202,12 +171,6 @@ def rfscore_sigmoid_full(
     >>> df.filter(df['pIa'] > 0.5).count()
     0
     """
-    if min_rising_points is None:
-        min_rising_points = pd.Series([2])
-    if min_data_points is None:
-        min_data_points = pd.Series([4])
-    if rising_criteria is None:
-        rising_criteria = pd.Series(["ewma"])
     mask = apply_selection_cuts_ztf(magpsf, ndethist, cdsxmatch)
 
     if len(jd[mask]) == 0:
@@ -216,13 +179,8 @@ def rfscore_sigmoid_full(
     candid = pd.Series(range(len(jd)))
     pdf = format_data_as_snana(jd, magpsf, sigmapsf, fid, candid, mask)
 
-    # Load pre-trained model `clf`
-    if model is not None:
-        clf = load_scikit_model(model.to_numpy()[0])
-    else:
-        curdir = os.path.dirname(os.path.abspath(__file__))
-        model = curdir + "/data/models/default-model_sigmoid.obj"
-        clf = load_scikit_model(model)
+    curdir = os.path.dirname(os.path.abspath(__file__))
+    clf = load_scikit_model(curdir + "/data/models/default-model_sigmoid.obj")
 
     test_features = []
     flag = []
@@ -230,9 +188,9 @@ def rfscore_sigmoid_full(
     for _, pdf_sub in pdf.groupby("SNID"):
         features = get_sigmoid_features_dev_fast(
             pdf_sub,
-            min_rising_points=min_rising_points.to_numpy()[0],
-            min_data_points=min_data_points.to_numpy()[0],
-            rising_criteria=rising_criteria.to_numpy()[0],
+            min_rising_points=2,
+            min_data_points=4,
+            rising_criteria="ewma",
         )
         if (features[0] == 0) or (features[6] == 0):
             flag.append(False)
@@ -258,7 +216,7 @@ def rfscore_sigmoid_full(
     return pd.Series(to_return)
 
 
-@pandas_udf(StringType(), PandasUDFType.SCALAR)
+@pandas_udf(StringType())
 @profile
 def extract_features_rf_snia(
     jd: pd.Series,
@@ -267,15 +225,14 @@ def extract_features_rf_snia(
     sigmapsf: pd.Series,
     cdsxmatch: pd.Series,
     ndethist: pd.Series,
-    min_rising_points=None,
-    min_data_points=None,
-    rising_criteria=None,
 ) -> pd.Series:
     """Return the features used by the RF classifier.
 
     There are 12 features. Order is:
     a_g,b_g,c_g,snratio_g,chisq_g,nrise_g,
     a_r,b_r,c_r,snratio_r,chisq_r,nrise_r
+
+    Uses default parameters: min_rising_points=2, min_data_points=4, rising_criteria="ewma".
 
     Parameters
     ----------
@@ -289,10 +246,6 @@ def extract_features_rf_snia(
         Type of object found in Simbad (string)
     ndethist: Spark DataFrame Column
         Column containing the number of detection by ZTF at 3 sigma (int)
-    min_rising_points, min_data_points: int
-        Parameters from fink_sn_activelearning.git
-    rising_criteria: str
-        How to compute derivatives: ewma (default), or diff.
 
     Returns
     -------
@@ -332,13 +285,6 @@ def extract_features_rf_snia(
     >>> df.agg({RF_FEATURE_NAMES[0]: "min"}).collect()[0][0]
     0.0
     """
-    if min_rising_points is None:
-        min_rising_points = pd.Series([2])
-    if min_data_points is None:
-        min_data_points = pd.Series([4])
-    if rising_criteria is None:
-        rising_criteria = pd.Series(["ewma"])
-
     mask = apply_selection_cuts_ztf(magpsf, ndethist, cdsxmatch)
 
     if len(jd[mask]) == 0:
@@ -352,9 +298,9 @@ def extract_features_rf_snia(
     for _, pdf_sub in pdf.groupby("SNID"):
         features = get_sigmoid_features_dev_fast(
             pdf_sub,
-            min_rising_points=min_rising_points.to_numpy()[0],
-            min_data_points=min_data_points.to_numpy()[0],
-            rising_criteria=rising_criteria.to_numpy()[0],
+            min_rising_points=2,
+            min_data_points=4,
+            rising_criteria="ewma",
         )
         test_features.append(features)
 

--- a/fink_science/ztf/snn/processor.py
+++ b/fink_science/ztf/snn/processor.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from line_profiler import profile
 
-from pyspark.sql.functions import pandas_udf, PandasUDFType
+from pyspark.sql.functions import pandas_udf
 from pyspark.sql.types import DoubleType
 
 from supernnova.validation.validate_onthefly import classify_lcs
@@ -81,7 +81,7 @@ def apply_selection_cuts_ztf(
     return mask
 
 
-@pandas_udf(DoubleType(), PandasUDFType.SCALAR)
+@pandas_udf(DoubleType())
 @profile
 def snn_ia(
     candid: pd.Series,
@@ -93,7 +93,6 @@ def snn_ia(
     cdsxmatch: pd.Series,
     jdstarthist: pd.Series,
     model_name: pd.Series,
-    model_ext=None,
 ) -> pd.Series:
     """Compute probabilities of alerts to be SN Ia using SuperNNova
 
@@ -111,8 +110,6 @@ def snn_ia(
         SuperNNova pre-trained model. Currently available:
             * snn_snia_vs_nonia
             * snn_sn_vs_all
-    model_ext: Spark DataFrame Column, optional
-        Path to the trained model (overwrite `model`). Default is None
 
     Returns
     -------
@@ -157,15 +154,6 @@ def snn_ia(
     >>> df.filter(df['pIa'] > 0.5).count()
     6
 
-    # Note that we can also specify a model
-    >>> args = [F.col(i) for i in ['candid', 'cjd', 'cfid', 'cmagpsf', 'csigmapsf']]
-    >>> args += [F.col('roid'), F.col('cdsxmatch'), F.col('candidate.jdstarthist')]
-    >>> args += [F.lit(''), F.lit(model_path)]
-    >>> df = df.withColumn('pIa2', snn_ia(*args))
-
-    >>> df.filter(df['pIa2'] > 0.5).count()>5
-    True
-
     # Check robustness wrt i-band
     >>> df = spark.read.load(ztf_alert_with_i_band)
 
@@ -200,15 +188,10 @@ def snn_ia(
     candid = candid.apply(lambda x: str(x))
     pdf = format_data_as_snana(jd, magpsf, sigmapsf, fid, candid, mask)
 
-    if model_ext is not None:
-        # take the first element of the Series
-        model = model_ext.to_numpy()[0]
-    else:
-        # Load pre-trained model
-        curdir = os.path.dirname(os.path.abspath(__file__))
-        model = curdir + "/data/models/snn_models/{}/model.pt".format(
-            model_name.to_numpy()[0]
-        )
+    curdir = os.path.dirname(os.path.abspath(__file__))
+    model = curdir + "/data/models/snn_models/{}/model.pt".format(
+        model_name.to_numpy()[0]
+    )
 
     # Compute predictions
     pdf = pdf.dropna()
@@ -241,8 +224,6 @@ if __name__ == "__main__":
     )
     globs["ztf_alert_with_i_band"] = ztf_alert_with_i_band
 
-    model_path = "{}/data/models/snn_models/snn_sn_vs_all/model.pt".format(path)
-    globs["model_path"] = model_path
 
     # Run the test suite
     spark_unit_tests(globs)

--- a/fink_science/ztf/snn/processor.py
+++ b/fink_science/ztf/snn/processor.py
@@ -224,6 +224,5 @@ if __name__ == "__main__":
     )
     globs["ztf_alert_with_i_band"] = ztf_alert_with_i_band
 
-
     # Run the test suite
     spark_unit_tests(globs)

--- a/fink_science/ztf/ssoft/processor.py
+++ b/fink_science/ztf/ssoft/processor.py
@@ -527,22 +527,24 @@ def extract_ssoft_parameters(
                 extract_array_from_series(jd, index, float),
                 extract_array_from_series(dobs, index, float),
             )
-            pdf = pd.DataFrame({
-                "cmred": magpsf_red,
-                "csigmapsf": extract_array_from_series(sigmapsf, index, float),
-                "Phase": extract_array_from_series(phase, index, float),
-                "cfid": extract_array_from_series(fid, index, int),
-                "ra": extract_array_from_series(raobs, index, float),
-                "dec": extract_array_from_series(decobs, index, float),
-                "cjd": jd_lt,
-                "i:raephem": extract_array_from_series(raephem, index, float),
-                "i:decephem": extract_array_from_series(decephem, index, float),
-                "ra_s": extract_array_from_series(raephem, index, float),
-                "dec_s": extract_array_from_series(decephem, index, float),
-                "cdx": extract_array_from_series(cdx, index, float),
-                "cdy": extract_array_from_series(cdy, index, float),
-                "Dhelio": extract_array_from_series(dhelio, index, float),
-            })
+            pdf = pd.DataFrame(
+                {
+                    "cmred": magpsf_red,
+                    "csigmapsf": extract_array_from_series(sigmapsf, index, float),
+                    "Phase": extract_array_from_series(phase, index, float),
+                    "cfid": extract_array_from_series(fid, index, int),
+                    "ra": extract_array_from_series(raobs, index, float),
+                    "dec": extract_array_from_series(decobs, index, float),
+                    "cjd": jd_lt,
+                    "i:raephem": extract_array_from_series(raephem, index, float),
+                    "i:decephem": extract_array_from_series(decephem, index, float),
+                    "ra_s": extract_array_from_series(raephem, index, float),
+                    "dec_s": extract_array_from_series(decephem, index, float),
+                    "cdx": extract_array_from_series(cdx, index, float),
+                    "cdy": extract_array_from_series(cdy, index, float),
+                    "Dhelio": extract_array_from_series(dhelio, index, float),
+                }
+            )
             pdf = pdf.sort_values("cjd")
 
             # Clean data in-place
@@ -565,9 +567,9 @@ def extract_ssoft_parameters(
             )
 
             # Wrap columns inplace
-            pdf_transposed = pd.DataFrame({
-                colname: [pdf[colname].to_numpy()] for colname in pdf.columns
-            })
+            pdf_transposed = pd.DataFrame(
+                {colname: [pdf[colname].to_numpy()] for colname in pdf.columns}
+            )
 
             base_kwargs = dict(
                 use_angles=True,
@@ -604,20 +606,22 @@ def extract_ssoft_parameters(
                 }
             )
         else:
-            pdf = pd.DataFrame({
-                "i:ssnamenr": [ssname] * len(raobs.to_numpy()[index]),
-                "i:magpsf": extract_array_from_series(magpsf, index, float),
-                "i:sigmapsf": extract_array_from_series(sigmapsf, index, float),
-                "i:jd": extract_array_from_series(jd, index, float),
-                "i:fid": extract_array_from_series(fid, index, int),
-                "i:ra": extract_array_from_series(raobs, index, float),
-                "i:dec": extract_array_from_series(decobs, index, float),
-                "i:raephem": extract_array_from_series(raephem, index, float),
-                "i:decephem": extract_array_from_series(decephem, index, float),
-                "i:magpsf_red": magpsf_red,
-                "Phase": extract_array_from_series(phase, index, float),
-                "Dobs": extract_array_from_series(dobs, index, float),
-            })
+            pdf = pd.DataFrame(
+                {
+                    "i:ssnamenr": [ssname] * len(raobs.to_numpy()[index]),
+                    "i:magpsf": extract_array_from_series(magpsf, index, float),
+                    "i:sigmapsf": extract_array_from_series(sigmapsf, index, float),
+                    "i:jd": extract_array_from_series(jd, index, float),
+                    "i:fid": extract_array_from_series(fid, index, int),
+                    "i:ra": extract_array_from_series(raobs, index, float),
+                    "i:dec": extract_array_from_series(decobs, index, float),
+                    "i:raephem": extract_array_from_series(raephem, index, float),
+                    "i:decephem": extract_array_from_series(decephem, index, float),
+                    "i:magpsf_red": magpsf_red,
+                    "Phase": extract_array_from_series(phase, index, float),
+                    "Dobs": extract_array_from_series(dobs, index, float),
+                }
+            )
 
             pdf = pdf.sort_values("i:jd")
 
@@ -788,8 +792,7 @@ def build_the_ssoft(
     # Note: we compute the size of Phase
     # because Phase can be null due to no ephemerides
     df = (
-        df
-        .withColumn("ephemmeasurements", F.size(df["Phase"]))
+        df.withColumn("ephemmeasurements", F.size(df["Phase"]))
         .filter(F.col("ephemmeasurements") >= nmin)
         .filter(F.size("cmagpsf") == F.size("Phase"))
         .repartition(nparts)
@@ -825,8 +828,7 @@ def build_the_ssoft(
     cols = ["ssnamenr", "params_str"]
     t0 = time.time()
     pdf = (
-        df
-        .withColumn(
+        df.withColumn(
             "params_str",
             extract_ssoft_parameters(
                 F.col("ssnamenr").astype("string"),

--- a/fink_science/ztf/standardized_flux/processor.py
+++ b/fink_science/ztf/standardized_flux/processor.py
@@ -142,33 +142,37 @@ def standardized_flux(
     CTAO_filename = "CTAO_blazars_ztf_dr{}.parquet".format(CATALOG_TAG)
     CTAO_blazar = pd.read_parquet(os.path.join(CTAO_PATH, CTAO_filename))
 
-    pdf = pd.DataFrame({
-        "candid": candid,
-        "objectId": objectId,
-        "cdistnr": cdistnr,
-        "cmagpsf": cmagpsf,
-        "csigmapsf": csigmapsf,
-        "cmagnr": cmagnr,
-        "csigmagnr": csigmagnr,
-        "cisdiffpos": cisdiffpos,
-        "cfid": cfid,
-        "cjd": cjd,
-    })
+    pdf = pd.DataFrame(
+        {
+            "candid": candid,
+            "objectId": objectId,
+            "cdistnr": cdistnr,
+            "cmagpsf": cmagpsf,
+            "csigmapsf": csigmapsf,
+            "cmagnr": cmagnr,
+            "csigmagnr": csigmagnr,
+            "cisdiffpos": cisdiffpos,
+            "cfid": cfid,
+            "cjd": cjd,
+        }
+    )
     out = []
     for candid_ in pdf["candid"]:
         tmp = pdf[pdf["candid"] == candid_]
-        sub = pd.DataFrame({
-            "candid": tmp["candid"].to_numpy()[0],
-            "objectId": tmp["objectId"].to_numpy()[0],
-            "cdistnr": tmp["cdistnr"].to_numpy()[0],
-            "cmagpsf": tmp["cmagpsf"].to_numpy()[0],
-            "csigmapsf": tmp["csigmapsf"].to_numpy()[0],
-            "cmagnr": tmp["cmagnr"].to_numpy()[0],
-            "csigmagnr": tmp["csigmagnr"].to_numpy()[0],
-            "cisdiffpos": tmp["cisdiffpos"].to_numpy()[0],
-            "cfid": tmp["cfid"].to_numpy()[0],
-            "cjd": tmp["cjd"].to_numpy()[0],
-        })
+        sub = pd.DataFrame(
+            {
+                "candid": tmp["candid"].to_numpy()[0],
+                "objectId": tmp["objectId"].to_numpy()[0],
+                "cdistnr": tmp["cdistnr"].to_numpy()[0],
+                "cmagpsf": tmp["cmagpsf"].to_numpy()[0],
+                "csigmapsf": tmp["csigmapsf"].to_numpy()[0],
+                "cmagnr": tmp["cmagnr"].to_numpy()[0],
+                "csigmagnr": tmp["csigmagnr"].to_numpy()[0],
+                "cisdiffpos": tmp["cisdiffpos"].to_numpy()[0],
+                "cfid": tmp["cfid"].to_numpy()[0],
+                "cjd": tmp["cjd"].to_numpy()[0],
+            }
+        )
         std_flux = standardized_flux_(sub, CTAO_blazar)
         out.append({"flux": std_flux[0], "sigma": std_flux[1]})
 

--- a/fink_science/ztf/standardized_flux/utils.py
+++ b/fink_science/ztf/standardized_flux/utils.py
@@ -33,16 +33,18 @@ def standardized_flux_(pdf: pd.DataFrame, CTAO_blazar: pd.DataFrame) -> tuple:
     name = pdf["objectId"].to_numpy()[0]
     CTAO_data = CTAO_blazar.loc[CTAO_blazar["ZTF_name"] == name]
     if not CTAO_data.empty:
-        flux_dc, sigma_flux_dc = np.transpose([
-            apparent_flux(*args)
-            for args in zip(
-                pdf["cmagpsf"].astype(float).to_numpy(),
-                pdf["csigmapsf"].astype(float).to_numpy(),
-                pdf["cmagnr"].astype(float).to_numpy(),
-                pdf["csigmagnr"].astype(float).to_numpy(),
-                pdf["cisdiffpos"].to_numpy(),
-            )
-        ])
+        flux_dc, sigma_flux_dc = np.transpose(
+            [
+                apparent_flux(*args)
+                for args in zip(
+                    pdf["cmagpsf"].astype(float).to_numpy(),
+                    pdf["csigmapsf"].astype(float).to_numpy(),
+                    pdf["cmagnr"].astype(float).to_numpy(),
+                    pdf["csigmagnr"].astype(float).to_numpy(),
+                    pdf["cisdiffpos"].to_numpy(),
+                )
+            ]
+        )
 
         # Loop over g & r only
         for filter_ in [1, 2]:

--- a/fink_science/ztf/superluminous/processor.py
+++ b/fink_science/ztf/superluminous/processor.py
@@ -135,15 +135,17 @@ def superluminous_score(
     >>> sum(pdf['proba']==-1)
     121
     """
-    pdf = pd.DataFrame({
-        "is_transient": is_transient,
-        "objectId": objectId,
-        "jdstarthist": jdstarthist,
-        "cjd": cjd,
-        "cmagpsf": cmagpsf,
-        "csigmapsf": csigmapsf,
-        "cfid": cfid,
-    })
+    pdf = pd.DataFrame(
+        {
+            "is_transient": is_transient,
+            "objectId": objectId,
+            "jdstarthist": jdstarthist,
+            "cjd": cjd,
+            "cmagpsf": cmagpsf,
+            "csigmapsf": csigmapsf,
+            "cfid": cfid,
+        }
+    )
 
     pdf["jd"] = pdf["cjd"].apply(np.max)
 

--- a/fink_science/ztf/superluminous/slsn_classifier.py
+++ b/fink_science/ztf/superluminous/slsn_classifier.py
@@ -67,9 +67,9 @@ def compute_flux(pdf):
     >>> np.testing.assert_allclose(np.array([new["csigflux"][k] for k in range(2)]), true_err, rtol=1e-3)
     """
     conversion = pdf[["cmagpsf", "csigmapsf"]].apply(
-        lambda x: np.transpose([
-            mag2fluxcal_snana(*i) for i in zip(x["cmagpsf"], x["csigmapsf"])
-        ]),
+        lambda x: np.transpose(
+            [mag2fluxcal_snana(*i) for i in zip(x["cmagpsf"], x["csigmapsf"])]
+        ),
         axis=1,
     )
 
@@ -370,15 +370,17 @@ def remove_nan(pdf):
     for k in ["cjd", "cmagpsf", "csigmapsf", "cfid", "csigflux", "cflux"]:
         if k in pdf.columns:
             pdf.loc[:, k] = pdf.apply(
-                lambda row: np.array([
-                    a
-                    for a, b in zip(
-                        row[k],
-                        (np.array(row["cflux"]) == row["cflux"])
-                        & (np.array(row["cflux"]) != None),  # noqa: E711
-                    )
-                    if b
-                ]),
+                lambda row: np.array(
+                    [
+                        a
+                        for a, b in zip(
+                            row[k],
+                            (np.array(row["cflux"]) == row["cflux"])
+                            & (np.array(row["cflux"]) != None),  # noqa: E711
+                        )
+                        if b
+                    ]
+                ),
                 axis=1,
             )
 
@@ -410,14 +412,16 @@ def remove_bad_bands(pdf):
     for k in ["cjd", "cmagpsf", "csigmapsf", "csigflux", "cflux", "cfid"]:
         if k in pdf.columns:
             pdf.loc[:, k] = pdf.apply(
-                lambda row: np.array([
-                    a
-                    for a, b in zip(
-                        row[k],
-                        (np.isin(row["cfid"], list(kern.band_wave_aa.keys()))),  # noqa: E711
-                    )
-                    if b
-                ]),
+                lambda row: np.array(
+                    [
+                        a
+                        for a, b in zip(
+                            row[k],
+                            (np.isin(row["cfid"], list(kern.band_wave_aa.keys()))),  # noqa: E711
+                        )
+                        if b
+                    ]
+                ),
                 axis=1,
             )
 

--- a/fink_science/ztf/transient_features/processor.py
+++ b/fink_science/ztf/transient_features/processor.py
@@ -34,8 +34,7 @@ from fink_science.tester import spark_unit_tests
 def extract_intermediate_cols(df):
     """Add intermediate columns"""
     df = (
-        df
-        .withColumn("m_now", col("candidate.magpsf"))
+        df.withColumn("m_now", col("candidate.magpsf"))
         .withColumn("t_now", col("candidate.jd"))
         .withColumn("m_app", col("candidate.magap"))
         .withColumn("fid_now", col("candidate.fid"))

--- a/fink_science/ztf/xmatch/processor.py
+++ b/fink_science/ztf/xmatch/processor.py
@@ -399,11 +399,13 @@ def xmatch_tns(df, distmaxarcsec=1.5, tns_raw_output=""):
         # cross-match
         _, _, _ = catalog_tns.match_to_catalog_sky(catalog_ztf)
 
-        sub_pdf = pd.DataFrame({
-            "objectId": objectid.to_numpy(),
-            "ra": ra.to_numpy(),
-            "dec": dec.to_numpy(),
-        })
+        sub_pdf = pd.DataFrame(
+            {
+                "objectId": objectid.to_numpy(),
+                "ra": ra.to_numpy(),
+                "dec": dec.to_numpy(),
+            }
+        )
 
         # cross-match
         idx2, d2d2, _ = catalog_ztf.match_to_catalog_sky(catalog_tns)
@@ -550,11 +552,13 @@ def crossmatch_other_catalog(
     +---+-----------+-----------+-----------------+
     <BLANKLINE>
     """
-    pdf = pd.DataFrame({
-        "ra": ra.to_numpy(),
-        "dec": dec.to_numpy(),
-        "candid": range(len(ra)),
-    })
+    pdf = pd.DataFrame(
+        {
+            "ra": ra.to_numpy(),
+            "dec": dec.to_numpy(),
+            "candid": range(len(ra)),
+        }
+    )
 
     curdir = os.path.dirname(os.path.abspath(__file__))
     if catalog_name.to_numpy()[0] == "gcvs":
@@ -652,11 +656,13 @@ def crossmatch_mangrove(
     2  3    0.312600  47.685900  {'HyperLEDA_name': 'None', '2MASS_name': 'None...
     3  4    0.318208  29.592778  {'HyperLEDA_name': 'None', '2MASS_name': 'None...
     """
-    pdf = pd.DataFrame({
-        "ra": ra.to_numpy(),
-        "dec": dec.to_numpy(),
-        "candid": range(len(ra)),
-    })
+    pdf = pd.DataFrame(
+        {
+            "ra": ra.to_numpy(),
+            "dec": dec.to_numpy(),
+            "candid": range(len(ra)),
+        }
+    )
 
     curdir = os.path.dirname(os.path.abspath(__file__))
     catalog = curdir + "/data/catalogs/mangrove_filtered.parquet"

--- a/fink_science/ztf/xmatch/utils.py
+++ b/fink_science/ztf/xmatch/utils.py
@@ -57,10 +57,12 @@ def cross_match_astropy(pdf, catalog_ztf, catalog_other, radius_arcsec=None):
     catalog_matches = np.unique(pdf["candid"].to_numpy()[idx[sep_constraint]])
 
     # identify position of matches in the input dataframe
-    pdf_matches = pd.DataFrame({
-        "candid": np.array(catalog_matches, dtype=np.int64),
-        "match": True,
-    })
+    pdf_matches = pd.DataFrame(
+        {
+            "candid": np.array(catalog_matches, dtype=np.int64),
+            "match": True,
+        }
+    )
     pdf_merge = pdf.merge(pdf_matches, how="left", on="candid")
 
     mask = pdf_merge["match"].apply(lambda x: x is True)


### PR DESCRIPTION
## Summary
- Replace `@pandas_udf(Type(), PandasUDFType.SCALAR)` with `@pandas_udf(Type())`, the recommended form since Spark 3.0 (SPARK-28264)
- Remove `warnings.filterwarnings` workarounds that suppressed the deprecation warning instead of fixing the root cause

## Related
- astrolabsoftware/fink-broker#1200
- astrolabsoftware/fink-broker-images#37
