### PR TITLE
[Rubin] image concentration module

### DIFF
--- a/fink_science/rubin/concentration/processor.py
+++ b/fink_science/rubin/concentration/processor.py
@@ -1,0 +1,132 @@
+# Copyright 2019-2026 AstroLab Software
+# Author: Preeti Cowan, Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Compute the concentration of the fluxes within 2 pre-selected radii using stamps."""
+
+import os
+import io
+import logging
+from line_profiler import profile
+import numpy as np
+import pandas as pd
+from photutils.aperture import CircularAperture, aperture_photometry
+from astropy.io import fits
+
+from pyspark.sql.functions import pandas_udf
+from pyspark.sql.types import MapType, StringType, FloatType
+
+from fink_science import __file__
+from fink_science.tester import spark_unit_tests
+
+_LOG = logging.getLogger(__name__)
+
+
+def read_cutout_stamp(fits_bytes: bytes) -> np.ndarray:
+    """
+    Reads Rubin cutout stamps
+
+    Parameters
+    ----------
+    fits_bytes
+       input byte string
+    """
+    fits_buffer = io.BytesIO(fits_bytes)
+    with fits.open(fits_buffer) as hdulist:
+        return hdulist[0].data
+
+
+def concentration(image, center, radii):
+    """ """
+    fluxes = []
+    for r in radii:
+        ap = CircularAperture(center, r)
+        phot = aperture_photometry(image, ap)
+        fluxes.append(phot["aperture_sum"][0])
+
+    total_flux = np.max(fluxes)
+    if total_flux <= 0:
+        return np.nan
+
+    r20 = np.interp(0.20 * total_flux, fluxes, radii)
+    r80 = np.interp(0.80 * total_flux, fluxes, radii)
+
+    if r20 <= 0:
+        return np.nan
+    return 5.0 * np.log10(r80 / r20)
+
+
+@pandas_udf(MapType(StringType(), FloatType()))
+@profile
+def calculate_concentration(
+    cutoutScience: pd.Series, cutoutDifference: pd.Series
+) -> pd.Series:
+    """Compute the concentration of the fluxes within 2 pre-selected radii using stamps.
+
+    Notes
+    -----
+    Concentration index: C = 5 * log10(r80 / r20).
+    Stars have high C (flux tightly concentrated).
+    Comets have lower C (coma spreads the flux outward).
+
+    Parameters
+    ----------
+    cutoutScience: bytes
+        Science cutout
+    cutoutDifference: bytes
+        Difference cutout
+
+    Returns
+    -------
+    out: dict
+        cScience: concentration from the Science cutout
+        cDifference: concentration from the Difference cutout
+
+    Examples
+    --------
+    >>> df = spark.read.format('parquet').load(rubin_alert_sample)
+    >>> args = ['cutoutScience', 'cutoutDifference']
+    >>> df = df.withColumn('concentrations', calculate_concentration(*args))
+    >>> df = df.withColumn('cScience', df['concentrations'].getItem('cScience'))
+    >>> df = df.withColumn('cDifference', df['concentrations'].getItem('cDifference'))
+    >>> df.select(['diaObject.diaObjectId', 'cScience', 'cDifference']).show()
+    """
+    radii = np.arange(1, 14)
+    out = []
+    for index in range(len(cutoutScience)):
+        sci = read_cutout_stamp(cutoutScience.to_numpy()[index])
+        dif = read_cutout_stamp(cutoutDifference.to_numpy()[index])
+
+        # Assuming square cutouts with odd len
+        center = (len(sci) // 2, len(sci) // 2)
+
+        cScience = concentration(sci, center, radii)
+        cDifference = concentration(dif, center, radii)
+
+        out.append({"cScience": cScience, "cDifference": cDifference})
+
+    return pd.Series(out)
+
+
+if __name__ == "__main__":
+    """ Execute the test suite """
+
+    globs = globals()
+    path = os.path.dirname(__file__)
+
+    # from fink-alerts-schemas (see CI configuration)
+    rubin_alert_sample = "file://{}/datasim/rubin_test_data_10_0.parquet".format(path)
+    globs["rubin_alert_sample"] = rubin_alert_sample
+
+    # Run the test suite
+    spark_unit_tests(globs)

--- a/fink_science/rubin/concentration/processor.py
+++ b/fink_science/rubin/concentration/processor.py
@@ -91,6 +91,7 @@ def calculate_concentration(
     out: dict
         cScience: concentration from the Science cutout
         cDifference: concentration from the Difference cutout
+        cSizePixel: cutout size in pixel
 
     Examples
     --------
@@ -99,7 +100,8 @@ def calculate_concentration(
     >>> df = df.withColumn('concentrations', calculate_concentration(*args))
     >>> df = df.withColumn('cScience', df['concentrations'].getItem('cScience'))
     >>> df = df.withColumn('cDifference', df['concentrations'].getItem('cDifference'))
-    >>> df.select(['diaObject.diaObjectId', 'cScience', 'cDifference']).show()
+    >>> df = df.withColumn('cSizePixel', df['concentrations'].getItem('cSizePixel'))
+    >>> df.select(['diaObject.diaObjectId', 'cScience', 'cDifference', 'cSizePixel']).show()
     """
     radii = np.arange(1, 14)
     out = []
@@ -113,7 +115,7 @@ def calculate_concentration(
         cScience = concentration(sci, center, radii)
         cDifference = concentration(dif, center, radii)
 
-        out.append({"cScience": cScience, "cDifference": cDifference})
+        out.append({"cScience": cScience, "cDifference": cDifference, 'cSizePixel': len(sci)})
 
     return pd.Series(out)
 


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #708

## What changes were proposed in this pull request?

New module to compute concentration factor on Science and Difference cutout. Cutout size, in pixel, is also returned.

## Results

### Solar system objects

I ran the module on all alerts from 2026-04-01 (when the SSO pipeline started to be more reliable). This is about 500k observations (~130k unique objects). I extracted concentrations, cutout size, and SNR:

```python
df = df.withColumn('concentrations', calculate_concentration(*args))

df = df.withColumn('cScience', df['concentrations'].getItem('cScience'))
df = df.withColumn('cDifference', df['concentrations'].getItem('cDifference'))
df = df.withColumn('cSizePixel', df['concentrations'].getItem('cSizePixel'))

df = df.filter(df['diaSource.midpointMjdTai'] > Time('2026-04-01').mjd).filter(df['mpc_orbits'].isNotNull())

pdf = df.select(['mpc_orbits.designation', 'cScience', 'cDifference', 'diaSource.snr', 'cSizePixel', 'diaSource.midpointMjdTai']).toPandas()
```

Some statistics first:

```python
pdf[['cScience']].describe()
            cScience
count  503859.000000
mean        2.796938
std         0.744016
min         0.000000
25%         2.428975
50%         2.550861
75%         2.865789
max         5.569717

pdf[['cDifference']].describe()
         cDifference
count  503847.000000
mean        2.725416
std         0.607813
min         0.000000
25%         2.433495
50%         2.532158
75%         2.719341
max         5.569717
```

The distributions are somehow similar. Let's check some objects. I ordered things of interest like:

```python
# large cutout could be a sign of activity
c1 = pdf['cutout_size'] > 100) 

# small values in the difference
c2 = pdf['cDifference'] < 3

# sort for cScience values - small values first
pdf[c1 * c2].sort_values('cScience', ascending=True)

       designation  cScience  cDifference          snr  cSizePixel  midpointMjdTai
359020   2013 NS27  0.743455     2.655851    26.045044        102.0    61185.181985
19391    2006 TL16  0.903093     2.663536    40.538097        102.0    61185.070081
58091    2006 RQ15  1.064346     2.586120    44.503765        102.0    61144.060519
241597   2018 VH29  1.113683     2.504450    29.126104        102.0    61185.186047
102291   1998 VG32  1.558913     2.204297   153.120163        102.0    61232.319469
491248   2011 YS18  1.692753     2.848047    15.925961        102.0    61144.066427
66482   2014 KP156  1.693410     2.832795    13.380005        102.0    61218.424693
58364    2011 YS18  1.695249     2.605628    15.285239        102.0    61144.065961
442371   2012 HQ44  2.064119     2.179120    27.955864        102.0    61232.318987
....
```

The object [2011 YS18](https://lsst.fink-portal.org/K11Y18S) is typical from the sample (tips: look at the mjd, find it on the lightcurve using the hover information, and click on the measurement to update the cutouts display):

<img width="1493" height="709" alt="image" src="https://github.com/user-attachments/assets/f19cb3bd-b588-4935-bbcc-de3c62496eab" />

It has a small `cScience` due to the presence of a star or galaxy in background, and `cDifference` is bigger as it is subtracted.

If now I take smaller cutouts:

```python
# small cutouts
c1 = pdf['cutout_size'] < 100) 

# small values in the difference
c2 = pdf['cDifference'] < 2

# sort for cScience values - small values first
pdf[c1 * c2].sort_values('cScience', ascending=True)

       designation  cScience  cDifference        snr  cutout_size  midpointMjdTai
281566   2019 GW83       0.0     0.000000   8.075841         30.0    61221.365989
373052  2015 BM589       0.0     0.000000   6.248260         30.0    61231.238552
290332    2025 KZ7       0.0     0.000000   8.087326         30.0    61218.356118
289057   2021 EL23       0.0     0.000000   6.545914         30.0    61221.330204
286247   2004 CW13       0.0     0.000000   8.830751         30.0    61221.322707
285812  2005 UZ338       0.0     0.000000   6.871990         30.0    61231.267326
285708  2005 WN133       0.0     0.000000   5.797455         30.0    61231.266838
285257  2015 DV135       0.0     0.000000   6.807235         30.0    61231.264453
284632  2015 BH259       0.0     0.000000   7.786944         30.0    61218.358789
....
```

I end up with a lot of zeros. Note that they usually have low SNR i.e. we are comparing noise... Note very interesting, let's filter them out:

```python
# small cutouts
c1 = pdf['cutout_size'] < 100) 

# small values in the difference
c2 = pdf['cDifference'] < 2

# non-zero
c3 = (pdf['cScience'] > 0) * (pdf['cDifference'] > 0)

# sort for cScience values - small values first
pdf[c1 * c2 * c3].sort_values('cScience', ascending=True)

       designation  cScience  cDifference        snr  cutout_size  midpointMjdTai
428098  2006 SP424  0.533716     1.931151  10.635092         30.0    61234.289908
11784    2006 AT46  0.660010     1.991294  17.274942         30.0    61227.319587
174798  2004 TQ352  0.774194     1.927416  16.583275         30.0    61234.248576
250677  2016 CP240  0.813276     1.965233  13.338768         38.0    61183.285550
440278  2008 RU190  0.853936     1.931194  11.294347         30.0    61203.328960
...
```

Here we see objects nearby at the border of the cutout contaminating the concentration calculation (we can see the large difference between `cScience` and `cDifference` -- and the borders are easily missed out), e.g. for [2006 SP424](https://lsst.fink-portal.org/K06Sg4P):

<img width="1493" height="709" alt="image" src="https://github.com/user-attachments/assets/95b4554f-5584-4063-adba-a749eb94f647" />

Let's restrict even more the concentration on the difference to have small values for concentrations everywhere by imposing `c2 = pdf['cDifference'] < 1`:

```python
       designation  cScience  cDifference        snr  cutout_size  midpointMjdTai
453121   2014 GX16  2.423597     0.636889  16.417109         30.0    61235.368648
138073    2021 AB4  2.444182     0.226936  14.505659         32.0    61230.234386
121554   2014 YS74  2.499024     0.933709  39.948406         31.0    61235.342433
496842  2012 XA178  2.567044     0.332112  10.008698         30.0    61205.093439
176624  2016 TN205  2.591192     0.082505  21.373264         47.0    61234.195480
336232  2008 GT155  2.650095     0.895950  37.999451         30.0    61230.246695
448814    2022 OU6  2.688207     0.844059   5.166552         30.0    61234.238760
354203  2005 UM257  2.893277     0.838092  25.481380         30.0    61218.269050
```

This time, there are not many objects left, with high `cScience` -- actually most of the time, the asteroid happens to pass on top of star, e.g. in 

<img width="1493" height="709" alt="image" src="https://github.com/user-attachments/assets/1401fae0-f1c5-481f-942b-879efc88cc9e" />

Beyond visual inspection, I did not run a deep analysis -- but we can already clearly see the contaminants we will have to face. Note that the SSO lightcurves are not super big, so even if we could isolate a good candidate based on concentration values, we wouldn't have many references to compare with (in case of activation).

### Static objects

I ran the module on all alerts from 2026-04-01 to match dates for SSO above. This is about 5M observations (~3.5M unique objects). I extracted concentrations, cutout size, and SNR:

```python
df = df.withColumn('concentrations', calculate_concentration(*args))

df = df.withColumn('cScience', df['concentrations'].getItem('cScience'))
df = df.withColumn('cDifference', df['concentrations'].getItem('cDifference'))
df = df.withColumn('cSizePixel', df['concentrations'].getItem('cSizePixel'))

df = df.filter(df['diaSource.midpointMjdTai'] > Time('2026-04-01').mjd).filter(df['mpc_orbits'].isNull())

pdf = df.select(['diaObject.diaObjectId', 'cScience', 'cDifference', 'diaSource.snr', 'cSizePixel', 'diaSource.midpointMjdTai']).toPandas()

pdf = pdf.dropna(subset=['cDifference', 'cScience'])
```

Some statistics:

```python
pdf[['cScience']].describe()
           cScience
count  3.894371e+06
mean   2.649954e+00
std    5.266311e-01
min    0.000000e+00
25%    2.433395e+00
50%    2.524880e+00
75%    2.647192e+00
max    5.569717e+00

pdf[['cDifference']].describe() 
        cDifference
count  3.894371e+06
mean   1.976256e+00
std    2.166894e+00
min   -7.033206e-01
25%    0.000000e+00
50%    7.119227e-01
75%    4.170551e+00
max    5.569717e+00
```

Interestingly, the distribution for `cScience` is similar than the one for Solar System objects, but `cDifference` is very different. On the few I checked, they are all bad subtractions. We should probably target those without a counterpart in the template.

Interestingly, we know Rubin observed comets but did not link to them to SSO. For example [170631096324063692](https://lsst.fink-portal.org/170631096324063692) is an observation of [C/2025 M2 (PANSTARRS)](https://api.ssodnet.imcce.fr/quaero/1/sso/search?q=%22C/2025%20M2%22%20AND%20type:Comet). The concentration values are `cScience=2.395163` and `cDifference=2.398983`. This is clearly not what I expected given the distribution of `cScience` and `cDifference` -- they have nothing exceptional. Maybe a sign that something needs to be worked out.

## How was this patch tested?

CI and cloud.
